### PR TITLE
Fix framenavigated dialog cleanup firing on subframe navigations

### DIFF
--- a/src/browser/page-manager.ts
+++ b/src/browser/page-manager.ts
@@ -123,10 +123,13 @@ export class PageManager {
       };
     });
 
-    // Clear stale dialog references on navigation
-    page.on("framenavigated", () => {
-      managedPage.pendingDialog = null;
-      managedPage.pendingDialogInfo = null;
+    // Clear stale dialog references on main-frame navigation only.
+    // Subframe navigations (iframes, ads, embeds) must not wipe dialog state.
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) {
+        managedPage.pendingDialog = null;
+        managedPage.pendingDialogInfo = null;
+      }
     });
 
     this.pages.set(tabId, managedPage);


### PR DESCRIPTION
## Summary
- Filter `framenavigated` listener in `PageManager.openTab()` to only clear dialog state on main-frame navigations
- Previously fired for all frames including iframes, which could prematurely wipe pending dialog state on pages with autonomously navigating subframes (ads, analytics, embeds)

Fixes #32

## Test plan
- [x] Full test suite passes (298/298)
- [x] All 16 dialog integration tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)