### PR TITLE
Fix pseudo-element content duplication in content extraction

### DIFF
--- a/src/renderer/content-extractor.ts
+++ b/src/renderer/content-extractor.ts
@@ -139,11 +139,19 @@ export class ContentExtractor {
     const textParts: string[] = [];
 
     const traverse = (node: ParsedAXNode) => {
-      // Include text from nodes that represent content
+      // Include text from nodes that represent content.
+      // For content-role nodes (headings, paragraphs, etc.), the AX tree `name`
+      // already includes all descendant text including CSS pseudo-element content.
+      // We emit the name and skip children to avoid duplicating that text.
+      if (node.name && isContentRole(node.role)) {
+        textParts.push(node.name);
+        return;
+      }
+
+      // For StaticText/text nodes not under a content-role parent (which would
+      // have returned above), include the text directly.
       if (node.role === "StaticText" || node.role === "text") {
         if (node.name) textParts.push(node.name);
-      } else if (node.name && isContentRole(node.role)) {
-        textParts.push(node.name);
       }
 
       for (const child of node.children) {

--- a/tests/fixtures/pages/pseudo-elements.html
+++ b/tests/fixtures/pages/pseudo-elements.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pseudo Element Test Page</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+
+    /* ::before pseudo-element on heading */
+    h1.before-icon::before {
+      content: "\2605 ";  /* star character + space */
+    }
+
+    /* ::after pseudo-element on heading */
+    h2.after-arrow::after {
+      content: " \2192";  /* space + right arrow */
+    }
+
+    /* Both ::before and ::after on heading */
+    h2.both-decorations::before {
+      content: "[ ";
+    }
+    h2.both-decorations::after {
+      content: " ]";
+    }
+
+    /* Decorative-only pseudo-elements (no text content duplication expected) */
+    h3.decorative-before::before {
+      content: "";
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      background: red;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+
+    /* Pseudo-element on a paragraph */
+    p.note::before {
+      content: "Note: ";
+      font-weight: bold;
+    }
+
+    /* Pseudo-element on a link */
+    a.external::after {
+      content: " \2197";  /* external link icon */
+    }
+  </style>
+</head>
+<body>
+  <main role="main" aria-label="Content">
+    <h1 class="before-icon">Welcome to the Site</h1>
+
+    <h2 class="after-arrow">Getting Started</h2>
+    <p>This section covers the basics.</p>
+
+    <h2 class="both-decorations">Features Overview</h2>
+    <p>A list of features available.</p>
+
+    <h3 class="decorative-before">Visual Indicator</h3>
+    <p class="note">This paragraph has a prefix via pseudo-element.</p>
+
+    <h2>Plain Heading</h2>
+    <p>This heading has no pseudo-elements for comparison.</p>
+
+    <a class="external" href="https://example.com">Example Link</a>
+  </main>
+</body>
+</html>

--- a/tests/integration/pseudo-elements.test.ts
+++ b/tests/integration/pseudo-elements.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as path from "node:path";
+import { BrowserManager } from "../../src/browser/browser-manager.js";
+import { CDPSessionManager } from "../../src/browser/cdp-session.js";
+import { RendererPipeline } from "../../src/renderer/renderer-pipeline.js";
+import { ElementIdGenerator } from "../../src/renderer/element-id-generator.js";
+import type { Page } from "puppeteer";
+
+const FIXTURE_PATH = path.resolve(
+  import.meta.dirname,
+  "../fixtures/pages/pseudo-elements.html",
+);
+
+describe("Pseudo-element content deduplication", () => {
+  let browserManager: BrowserManager;
+  let cdpSessionManager: CDPSessionManager;
+  let elementIdGenerator: ElementIdGenerator;
+  let pipeline: RendererPipeline;
+  let page: Page;
+
+  beforeAll(async () => {
+    browserManager = new BrowserManager();
+    await browserManager.launch();
+    page = await browserManager.newPage();
+    cdpSessionManager = new CDPSessionManager();
+    elementIdGenerator = new ElementIdGenerator();
+    pipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator);
+
+    await page.goto(`file://${FIXTURE_PATH}`, { waitUntil: "load" });
+  });
+
+  afterAll(async () => {
+    await browserManager.close();
+  });
+
+  describe("heading text extraction", () => {
+    it("does not duplicate ::before pseudo-element content in heading text", async () => {
+      const result = await pipeline.render(page, { detail: "minimal" });
+
+      const h1 = result.structure.headings.find((h) => h.level === 1);
+      expect(h1).toBeDefined();
+      // The heading text should contain "Welcome to the Site" and possibly the star,
+      // but it should NOT have the star duplicated (e.g., "★ ★ Welcome to the Site")
+      expect(h1!.text).not.toMatch(/★.*★/);
+      // Also check it doesn't have doubled content in general
+      expect(h1!.text).not.toMatch(/Welcome.*Welcome/);
+    });
+
+    it("does not duplicate ::after pseudo-element content in heading text", async () => {
+      const result = await pipeline.render(page, { detail: "minimal" });
+
+      const gettingStarted = result.structure.headings.find(
+        (h) => h.text.includes("Getting Started"),
+      );
+      expect(gettingStarted).toBeDefined();
+      // Should not have the arrow duplicated
+      expect(gettingStarted!.text).not.toMatch(/→.*→/);
+      // Should not have doubled content
+      expect(gettingStarted!.text).not.toMatch(/Getting Started.*Getting Started/);
+    });
+
+    it("does not duplicate ::before and ::after pseudo-element content in heading text", async () => {
+      const result = await pipeline.render(page, { detail: "minimal" });
+
+      const features = result.structure.headings.find(
+        (h) => h.text.includes("Features Overview"),
+      );
+      expect(features).toBeDefined();
+      // Should not have brackets duplicated
+      expect(features!.text).not.toMatch(/\[.*\[/);
+      expect(features!.text).not.toMatch(/\].*\]/);
+      // Should not have doubled content
+      expect(features!.text).not.toMatch(/Features Overview.*Features Overview/);
+    });
+
+    it("includes pseudo-element content in heading text from AX tree", async () => {
+      const result = await pipeline.render(page, { detail: "minimal" });
+
+      // The AX tree correctly computes heading names that include pseudo-element content
+      const h1 = result.structure.headings.find((h) => h.level === 1);
+      expect(h1).toBeDefined();
+      expect(h1!.text).toContain("Welcome to the Site");
+      // The star from ::before should be present in the heading text
+      expect(h1!.text).toContain("\u2605");
+
+      const gettingStarted = result.structure.headings.find(
+        (h) => h.text.includes("Getting Started"),
+      );
+      expect(gettingStarted).toBeDefined();
+      // The arrow from ::after should be present
+      expect(gettingStarted!.text).toContain("\u2192");
+    });
+
+    it("leaves plain headings unchanged", async () => {
+      const result = await pipeline.render(page, { detail: "minimal" });
+
+      const plain = result.structure.headings.find(
+        (h) => h.text.includes("Plain Heading"),
+      );
+      expect(plain).toBeDefined();
+      expect(plain!.text).toBe("Plain Heading");
+    });
+  });
+
+  describe("full content extraction", () => {
+    it("does not duplicate pseudo-element content in full content output", async () => {
+      const result = await pipeline.render(page, { detail: "full" });
+      const fullContent = result.structure.full_content!;
+
+      expect(fullContent).toBeDefined();
+      // Count occurrences of "Welcome to the Site" — should appear exactly once
+      const welcomeMatches = fullContent.match(/Welcome to the Site/g);
+      expect(welcomeMatches).not.toBeNull();
+      expect(welcomeMatches!.length).toBe(1);
+
+      // "Getting Started" should appear exactly once
+      const gettingStartedMatches = fullContent.match(/Getting Started/g);
+      expect(gettingStartedMatches).not.toBeNull();
+      expect(gettingStartedMatches!.length).toBe(1);
+
+      // "Features Overview" should appear exactly once
+      const featuresMatches = fullContent.match(/Features Overview/g);
+      expect(featuresMatches).not.toBeNull();
+      expect(featuresMatches!.length).toBe(1);
+
+      // "Plain Heading" should also appear exactly once (was duplicated even without pseudo-elements)
+      const plainMatches = fullContent.match(/Plain Heading/g);
+      expect(plainMatches).not.toBeNull();
+      expect(plainMatches!.length).toBe(1);
+    });
+
+    it("preserves non-heading content in full output", async () => {
+      const result = await pipeline.render(page, { detail: "full" });
+      const fullContent = result.structure.full_content!;
+
+      // Paragraphs and other non-heading content should still appear
+      expect(fullContent).toContain("This section covers the basics.");
+      expect(fullContent).toContain("A list of features available.");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Content-role AX nodes (headings, paragraphs) have a computed `name` that already includes CSS `::before`/`::after` pseudo-element text
- The `extractFullContent()` traverse function was emitting both the parent name AND child StaticText nodes, causing duplicate text in `full_content` output
- Fix: emit the content-role node's name and skip child traversal to avoid re-emitting the same text

Fixes #35

## Test plan
- [x] New fixture page with headings using `::before`, `::after`, both, decorative-only, and no pseudo-elements
- [x] 7 integration tests verifying no duplication and correct content preservation
- [x] All 305 tests pass (298 existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)