### PR TITLE
Fix boolean parameter validation for string-coerced values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Charlotte will be documented in this file.
 - **`charlotte:upload`** — Set files on `<input type="file">` elements via CDP `DOM.setFileInputFiles`. Validates file existence and element type before upload. Closes GAP-02 from the Playwright MCP gap analysis.
 - **File input detection** — File inputs (`<input type="file">`) are now correctly identified as `file_input` type in page representations. Previously they appeared as `button` because Chromium's accessibility tree represents them with a button role. A post-extraction reclassification step checks the underlying DOM node.
 
+### Fixed
+
+- **Boolean parameter validation error** — `charlotte:console` and `charlotte:requests` `clear` parameter (and `charlotte:type` `clear_first`/`press_enter`) rejected string-coerced booleans (`"true"`/`"false"`) sent by some MCP clients. All boolean parameters now accept both native booleans and their string representations. Fixes #50.
+
 ## [0.4.1] - 2026-03-05
 
 ### Added

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -12,6 +12,7 @@ import {
   resolveElement,
   formatPageResponse,
   handleToolError,
+  coercedBoolean,
 } from "./tool-helpers.js";
 
 /** Maps short modifier names to Puppeteer KeyInput values. */
@@ -574,12 +575,10 @@ export function registerInteractionTools(
       inputSchema: {
         element_id: z.string().describe("Target input element ID"),
         text: z.string().describe("Text to enter"),
-        clear_first: z
-          .boolean()
+        clear_first: coercedBoolean
           .optional()
           .describe("Clear existing value before typing (default: true)"),
-        press_enter: z
-          .boolean()
+        press_enter: coercedBoolean
           .optional()
           .describe("Press Enter after typing (default: false)"),
       },

--- a/src/tools/monitoring.ts
+++ b/src/tools/monitoring.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logger } from "../utils/logger.js";
 import type { ToolDependencies } from "./tool-helpers.js";
-import { handleToolError } from "./tool-helpers.js";
+import { handleToolError, coercedBoolean } from "./tool-helpers.js";
 
 export function registerMonitoringTools(
   server: McpServer,
@@ -23,8 +23,7 @@ export function registerMonitoringTools(
           .describe(
             'Filter by log level. "all" (default) returns every message.',
           ),
-        clear: z
-          .boolean()
+        clear: coercedBoolean
           .optional()
           .describe(
             "Clear the message buffer after retrieval (default: false).",
@@ -106,8 +105,7 @@ export function registerMonitoringTools(
           .describe(
             "Minimum HTTP status code to include (e.g. 400 for errors only).",
           ),
-        clear: z
-          .boolean()
+        clear: coercedBoolean
           .optional()
           .describe(
             "Clear the request buffer after retrieval (default: false).",

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -8,6 +8,7 @@ import {
   renderActivePage,
   formatPageResponse,
   handleToolError,
+  coercedBoolean,
 } from "./tool-helpers.js";
 
 const CookieSchema = z.object({
@@ -15,8 +16,8 @@ const CookieSchema = z.object({
   value: z.string().describe("Cookie value"),
   domain: z.string().describe("Cookie domain"),
   path: z.string().optional().describe("Cookie path (default: '/')"),
-  secure: z.boolean().optional().describe("Secure flag"),
-  httpOnly: z.boolean().optional().describe("HttpOnly flag"),
+  secure: coercedBoolean.optional().describe("Secure flag"),
+  httpOnly: coercedBoolean.optional().describe("HttpOnly flag"),
   sameSite: z
     .enum(["Strict", "Lax", "None"])
     .optional()

--- a/src/tools/tool-helpers.ts
+++ b/src/tools/tool-helpers.ts
@@ -12,8 +12,19 @@ import type {
   InteractiveElement,
 } from "../types/page-representation.js";
 import type { DetailLevel } from "../renderer/renderer-pipeline.js";
+import { z } from "zod";
 import { CharlotteError, CharlotteErrorCode } from "../types/errors.js";
 import { diffRepresentations } from "../state/differ.js";
+
+/**
+ * Boolean schema that accepts both native booleans and string representations
+ * ("true"/"false"). Some MCP clients send boolean parameters as strings,
+ * causing Zod validation to reject them. This handles the coercion.
+ */
+export const coercedBoolean = z.preprocess(
+  (val) => (val === "true" ? true : val === "false" ? false : val),
+  z.boolean(),
+);
 
 export interface ToolDependencies {
   browserManager: BrowserManager;

--- a/tests/unit/tools/coerced-boolean.test.ts
+++ b/tests/unit/tools/coerced-boolean.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { coercedBoolean } from "../../../src/tools/tool-helpers.js";
+
+describe("coercedBoolean", () => {
+  it("accepts native true", () => {
+    expect(coercedBoolean.parse(true)).toBe(true);
+  });
+
+  it("accepts native false", () => {
+    expect(coercedBoolean.parse(false)).toBe(false);
+  });
+
+  it('coerces string "true" to true', () => {
+    expect(coercedBoolean.parse("true")).toBe(true);
+  });
+
+  it('coerces string "false" to false', () => {
+    expect(coercedBoolean.parse("false")).toBe(false);
+  });
+
+  it("rejects other strings", () => {
+    expect(() => coercedBoolean.parse("yes")).toThrow();
+    expect(() => coercedBoolean.parse("1")).toThrow();
+    expect(() => coercedBoolean.parse("")).toThrow();
+  });
+
+  it("rejects numbers", () => {
+    expect(() => coercedBoolean.parse(1)).toThrow();
+    expect(() => coercedBoolean.parse(0)).toThrow();
+  });
+
+  it("works with .optional()", () => {
+    const optionalSchema = coercedBoolean.optional();
+    expect(optionalSchema.parse(undefined)).toBeUndefined();
+    expect(optionalSchema.parse(true)).toBe(true);
+    expect(optionalSchema.parse("true")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Some MCP clients send boolean parameters as strings (`"true"`/`"false"`), causing Zod `z.boolean()` validation to reject them with `Expected boolean, received string`
- Add `coercedBoolean` schema helper using `z.preprocess()` that accepts both native booleans and string representations, rejecting all other values
- Applied to all boolean tool parameters: `clear` in `console`/`requests`, `clear_first`/`press_enter` in `type`, `secure`/`httpOnly` in cookie schema

Fixes #50

## Test plan

- [x] New unit tests for `coercedBoolean`: native true/false, string "true"/"false", rejects other strings and numbers, works with `.optional()`
- [x] `npm run test:unit` — 221/221 pass
- [x] `npx vitest run tests/integration/monitoring.test.ts` — 18/18 pass
- [x] `npx tsc --noEmit` — type check passes

// ticktockbent