### PR TITLE
Extract iframe content into page representation

### DIFF
--- a/src/browser/cdp-session.ts
+++ b/src/browser/cdp-session.ts
@@ -1,10 +1,14 @@
-import type { Page, CDPSession } from "puppeteer";
+import type { Page, CDPSession, Frame } from "puppeteer";
 import { logger } from "../utils/logger.js";
 
 const REQUIRED_DOMAINS = ["Accessibility", "DOM", "CSS", "Page", "Network"] as const;
 
+/** Domains needed for iframe frame sessions (subset — no Page/Network). */
+const FRAME_DOMAINS = ["Accessibility", "DOM", "CSS"] as const;
+
 export class CDPSessionManager {
   private sessions: WeakMap<Page, CDPSession> = new WeakMap();
+  private frameSessions = new Map<string, CDPSession>();
 
   async getSession(page: Page): Promise<CDPSession> {
     const existing = this.sessions.get(page);
@@ -14,13 +18,44 @@ export class CDPSessionManager {
 
     logger.debug("Creating new CDP session");
     const session = await page.createCDPSession();
-    await this.enableDomains(session);
+    await this.enableDomains(session, REQUIRED_DOMAINS);
     this.sessions.set(page, session);
     return session;
   }
 
-  private async enableDomains(session: CDPSession): Promise<void> {
-    for (const domain of REQUIRED_DOMAINS) {
+  /**
+   * Get or create a CDP session for a child frame.
+   * Uses the frame's own client for out-of-process (cross-origin) frames.
+   */
+  async getFrameSession(frame: Frame): Promise<CDPSession> {
+    const frameId = this.getFrameId(frame);
+    const existing = this.frameSessions.get(frameId);
+    if (existing) {
+      return existing;
+    }
+
+    logger.debug("Creating CDP session for frame", { frameId, url: frame.url() });
+    // CdpFrame exposes .client which is the CDP session for that frame's target.
+    // This is a Puppeteer internal (tested with puppeteer 24.x). If Puppeteer
+    // changes the internal API, this will need updating.
+    const session = (frame as any).client as CDPSession;
+    await this.enableDomains(session, FRAME_DOMAINS);
+    this.frameSessions.set(frameId, session);
+    return session;
+  }
+
+  /** Extract the CDP frame ID from a Puppeteer Frame. */
+  getFrameId(frame: Frame): string {
+    // Puppeteer Frame exposes _id as the CDP frame ID.
+    // This is a Puppeteer internal (tested with puppeteer 24.x).
+    return (frame as any)._id as string;
+  }
+
+  private async enableDomains(
+    session: CDPSession,
+    domains: readonly string[],
+  ): Promise<void> {
+    for (const domain of domains) {
       try {
         await session.send(`${domain}.enable` as any);
         logger.debug(`Enabled CDP domain: ${domain}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
   // Initialize renderer pipeline
   const cdpSessionManager = new CDPSessionManager();
   const elementIdGenerator = new ElementIdGenerator();
-  const rendererPipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator);
+  const rendererPipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator, config);
   const snapshotStore = new SnapshotStore(config.snapshotDepth);
 
   // Initialize screenshot artifact store
@@ -57,6 +57,7 @@ async function main(): Promise<void> {
     {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore,

--- a/src/renderer/accessibility-extractor.ts
+++ b/src/renderer/accessibility-extractor.ts
@@ -11,6 +11,8 @@ export interface ParsedAXNode {
   backendDOMNodeId: number | null;
   children: ParsedAXNode[];
   parent: ParsedAXNode | null;
+  /** CDP frame ID this node belongs to. Null for main frame. */
+  frameId: string | null;
 }
 
 const LANDMARK_ROLES = new Set([
@@ -83,10 +85,11 @@ function extractProperties(
 }
 
 export class AccessibilityExtractor {
-  async extract(session: CDPSession): Promise<ParsedAXNode[]> {
-    logger.debug("Extracting accessibility tree");
+  async extract(session: CDPSession, frameId?: string): Promise<ParsedAXNode[]> {
+    logger.debug("Extracting accessibility tree", { frameId: frameId ?? "main" });
 
-    const result = await session.send("Accessibility.getFullAXTree" as any);
+    const params = frameId ? { frameId } : {};
+    const result = await session.send("Accessibility.getFullAXTree" as any, params);
     const rawNodes: RawAXNode[] = (result as any).nodes;
 
     if (!rawNodes || rawNodes.length === 0) {
@@ -150,6 +153,7 @@ export class AccessibilityExtractor {
         backendDOMNodeId: raw.backendDOMNodeId ?? null,
         children: [],
         parent: null,
+        frameId: frameId ?? null,
       };
 
       nodeMap.set(raw.nodeId, parsed);

--- a/src/renderer/element-id-generator.ts
+++ b/src/renderer/element-id-generator.ts
@@ -5,6 +5,7 @@ import { hashToHex4 } from "../utils/hash.js";
 export class ElementIdGenerator {
   private idToBackendNodeId = new Map<string, number>();
   private backendNodeIdToId = new Map<number, string>();
+  private idToFrameId = new Map<string, string>();
   private usedIds = new Set<string>();
 
   generateId(
@@ -13,6 +14,7 @@ export class ElementIdGenerator {
     name: string,
     domPath: DOMPathSignature,
     backendDOMNodeId: number | null,
+    frameId?: string | null,
   ): string {
     const prefix = TYPE_PREFIX_MAP[elementType] ?? "el";
 
@@ -24,6 +26,7 @@ export class ElementIdGenerator {
       domPath.nearestLandmarkLabel ?? "",
       domPath.nearestLabelledContainer ?? "",
       String(domPath.siblingIndex),
+      frameId ?? "",
     ].join("|");
 
     const hexHash = hashToHex4(compositeKey);
@@ -45,11 +48,20 @@ export class ElementIdGenerator {
       this.backendNodeIdToId.set(backendDOMNodeId, candidateId);
     }
 
+    if (frameId) {
+      this.idToFrameId.set(candidateId, frameId);
+    }
+
     return candidateId;
   }
 
   resolveId(elementId: string): number | null {
     return this.idToBackendNodeId.get(elementId) ?? null;
+  }
+
+  /** Returns the CDP frame ID for an element, or null if it belongs to the main frame. */
+  resolveFrame(elementId: string): string | null {
+    return this.idToFrameId.get(elementId) ?? null;
   }
 
   getIdForBackendNode(backendDOMNodeId: number): string | null {
@@ -77,6 +89,7 @@ export class ElementIdGenerator {
   clear(): void {
     this.idToBackendNodeId.clear();
     this.backendNodeIdToId.clear();
+    this.idToFrameId.clear();
     this.usedIds.clear();
   }
 
@@ -88,6 +101,7 @@ export class ElementIdGenerator {
   replaceWith(other: ElementIdGenerator): void {
     this.idToBackendNodeId = new Map(other.idToBackendNodeId);
     this.backendNodeIdToId = new Map(other.backendNodeIdToId);
+    this.idToFrameId = new Map(other.idToFrameId);
     this.usedIds = new Set(other.usedIds);
   }
 }

--- a/src/renderer/frame-discovery.ts
+++ b/src/renderer/frame-discovery.ts
@@ -1,0 +1,159 @@
+import type { Page, Frame, CDPSession } from "puppeteer";
+import type { CDPSessionManager } from "../browser/cdp-session.js";
+import type { Bounds } from "../types/page-representation.js";
+import { logger } from "../utils/logger.js";
+
+export interface DiscoveredFrame {
+  frame: Frame;
+  frameId: string;
+  url: string;
+  /** CDP session for this frame (may be the parent's session for same-origin). */
+  session: CDPSession;
+  /** Bounds of the <iframe> element in page-level coordinates. */
+  iframeBounds: Bounds | null;
+  /** Cumulative offset from page origin to this frame's content origin. */
+  contentOffset: { x: number; y: number };
+}
+
+/**
+ * Discover all child frames in the page up to maxDepth levels.
+ * Returns frame metadata including CDP sessions and coordinate offsets.
+ */
+export async function discoverFrames(
+  page: Page,
+  cdpSessionManager: CDPSessionManager,
+  maxDepth: number,
+): Promise<DiscoveredFrame[]> {
+  const discovered: DiscoveredFrame[] = [];
+  const mainSession = await cdpSessionManager.getSession(page);
+
+  await traverseFrames(
+    page.mainFrame(),
+    mainSession,
+    cdpSessionManager,
+    { x: 0, y: 0 },
+    0,
+    maxDepth,
+    discovered,
+  );
+
+  logger.debug(`Discovered ${discovered.length} child frame(s)`);
+  return discovered;
+}
+
+async function traverseFrames(
+  parentFrame: Frame,
+  parentSession: CDPSession,
+  cdpSessionManager: CDPSessionManager,
+  parentOffset: { x: number; y: number },
+  currentDepth: number,
+  maxDepth: number,
+  discovered: DiscoveredFrame[],
+): Promise<void> {
+  if (currentDepth >= maxDepth) return;
+
+  const childFrames = parentFrame.childFrames();
+  if (childFrames.length === 0) return;
+
+  for (const childFrame of childFrames) {
+    // Skip frames without URLs or about:blank frames
+    const frameUrl = childFrame.url();
+    if (!frameUrl || frameUrl === "about:blank") {
+      continue;
+    }
+
+    try {
+      const frameId = cdpSessionManager.getFrameId(childFrame);
+
+      // Get the iframe element's bounds in the parent frame's coordinate space
+      const iframeBoundsInParent = await getIframeBounds(parentSession, frameId);
+
+      // Compute page-level offset: parent's offset + iframe element position
+      const contentOffset = {
+        x: parentOffset.x + (iframeBoundsInParent?.x ?? 0),
+        y: parentOffset.y + (iframeBoundsInParent?.y ?? 0),
+      };
+
+      // Page-level bounds for the iframe element
+      const iframeBounds = iframeBoundsInParent
+        ? {
+            x: contentOffset.x,
+            y: contentOffset.y,
+            w: iframeBoundsInParent.w,
+            h: iframeBoundsInParent.h,
+          }
+        : null;
+
+      // Get a CDP session for this frame
+      let frameSession: CDPSession;
+      try {
+        frameSession = await cdpSessionManager.getFrameSession(childFrame);
+      } catch (error) {
+        logger.debug(`Could not get session for frame ${frameUrl}`, error);
+        continue;
+      }
+
+      discovered.push({
+        frame: childFrame,
+        frameId,
+        url: frameUrl,
+        session: frameSession,
+        iframeBounds,
+        contentOffset,
+      });
+
+      // Recurse into nested iframes
+      await traverseFrames(
+        childFrame,
+        frameSession,
+        cdpSessionManager,
+        contentOffset,
+        currentDepth + 1,
+        maxDepth,
+        discovered,
+      );
+    } catch (error) {
+      logger.debug(`Failed to discover frame ${frameUrl}`, error);
+    }
+  }
+}
+
+/**
+ * Get the bounds of the <iframe> element that hosts a child frame.
+ * Uses the parent frame's CDP session to find the frame owner node.
+ */
+async function getIframeBounds(
+  parentSession: CDPSession,
+  childFrameId: string,
+): Promise<Bounds | null> {
+  try {
+    // Get the frame owner (the <iframe> element in the parent DOM)
+    const { backendNodeId } = await parentSession.send("DOM.getFrameOwner" as any, {
+      frameId: childFrameId,
+    });
+
+    if (!backendNodeId) return null;
+
+    const { model } = await parentSession.send("DOM.getBoxModel" as any, {
+      backendNodeId,
+    });
+
+    if (!model?.content) return null;
+
+    const quad: number[] = model.content;
+    const minX = Math.min(quad[0], quad[2], quad[4], quad[6]);
+    const minY = Math.min(quad[1], quad[3], quad[5], quad[7]);
+    const maxX = Math.max(quad[0], quad[2], quad[4], quad[6]);
+    const maxY = Math.max(quad[1], quad[3], quad[5], quad[7]);
+
+    return {
+      x: Math.round(minX),
+      y: Math.round(minY),
+      w: Math.round(maxX - minX),
+      h: Math.round(maxY - minY),
+    };
+  } catch (error) {
+    logger.debug(`Could not get iframe bounds for frame ${childFrameId}`, error);
+    return null;
+  }
+}

--- a/src/renderer/interactive-extractor.ts
+++ b/src/renderer/interactive-extractor.ts
@@ -76,6 +76,7 @@ export class InteractiveExtractor {
     rootNodes: ParsedAXNode[],
     boundsMap: Map<number, Bounds>,
     idGenerator: ElementIdGenerator,
+    frameId?: string,
   ): ExtractionResult {
     const elements: InteractiveElement[] = [];
     const formNodes: ParsedAXNode[] = [];
@@ -94,6 +95,7 @@ export class InteractiveExtractor {
           node.name,
           domPath,
           node.backendDOMNodeId,
+          frameId,
         );
 
         let bounds: Bounds | null = null;
@@ -162,7 +164,7 @@ export class InteractiveExtractor {
     }
 
     // Build form representations
-    const forms = this.buildFormRepresentations(formNodes, elements, idGenerator, boundsMap);
+    const forms = this.buildFormRepresentations(formNodes, elements, idGenerator, boundsMap, frameId);
 
     return { elements, forms };
   }
@@ -172,6 +174,7 @@ export class InteractiveExtractor {
     interactiveElements: InteractiveElement[],
     idGenerator: ElementIdGenerator,
     _boundsMap: Map<number, Bounds>,
+    frameId?: string,
   ): FormRepresentation[] {
     const forms: FormRepresentation[] = [];
 
@@ -183,6 +186,7 @@ export class InteractiveExtractor {
         formNode.name,
         domPath,
         formNode.backendDOMNodeId,
+        frameId,
       );
 
       // Collect IDs of interactive elements that are descendants of this form

--- a/src/renderer/layout-extractor.ts
+++ b/src/renderer/layout-extractor.ts
@@ -36,8 +36,11 @@ export class LayoutExtractor {
   async getBoundsForNodes(
     session: CDPSession,
     backendNodeIds: number[],
+    frameOffset?: { x: number; y: number },
   ): Promise<Map<number, Bounds>> {
     const boundsMap = new Map<number, Bounds>();
+    const offsetX = frameOffset?.x ?? 0;
+    const offsetY = frameOffset?.y ?? 0;
 
     // Process in parallel for performance, but cap concurrency
     const batchSize = 50;
@@ -51,7 +54,17 @@ export class LayoutExtractor {
       );
 
       for (const { nodeId, bounds } of results) {
-        boundsMap.set(nodeId, bounds ?? ZERO_BOUNDS);
+        if (bounds && (offsetX !== 0 || offsetY !== 0)) {
+          // Translate frame-local bounds to page-level coordinates
+          boundsMap.set(nodeId, {
+            x: bounds.x + offsetX,
+            y: bounds.y + offsetY,
+            w: bounds.w,
+            h: bounds.h,
+          });
+        } else {
+          boundsMap.set(nodeId, bounds ?? ZERO_BOUNDS);
+        }
       }
     }
 

--- a/src/renderer/renderer-pipeline.ts
+++ b/src/renderer/renderer-pipeline.ts
@@ -16,13 +16,17 @@ import {
 import { ContentExtractor } from "./content-extractor.js";
 import { ElementIdGenerator } from "./element-id-generator.js";
 import { computeDOMPathSignature } from "./dom-path.js";
+import { discoverFrames } from "./frame-discovery.js";
+import type { DiscoveredFrame } from "./frame-discovery.js";
 import type {
   PageRepresentation,
   InteractiveSummary,
+  IframeInfo,
   Landmark,
   Heading,
   Bounds,
 } from "../types/page-representation.js";
+import type { CharlotteConfig } from "../types/config.js";
 import { logger } from "../utils/logger.js";
 
 export type DetailLevel = "minimal" | "summary" | "full";
@@ -42,6 +46,7 @@ export class RendererPipeline {
   constructor(
     private cdpSessionManager: CDPSessionManager,
     private elementIdGenerator: ElementIdGenerator,
+    private config?: CharlotteConfig,
   ) {}
 
   async render(page: Page, options: RenderOptions): Promise<PageRepresentation> {
@@ -50,7 +55,7 @@ export class RendererPipeline {
 
     const session = await this.cdpSessionManager.getSession(page);
 
-    // Step 1: Extract accessibility tree
+    // Step 1: Extract accessibility tree (main frame)
     const rootNodes = await this.accessibilityExtractor.extract(session);
 
     // Step 2: Collect nodes that need layout data
@@ -99,10 +104,42 @@ export class RendererPipeline {
       interactiveSummary = this.buildInteractiveSummary(rootNodes);
     }
 
-    // Step 9: Atomically replace the shared ID generator
+    // Step 9: Extract iframe content if enabled
+    let iframeInfos: IframeInfo[] | undefined;
+
+    if (this.config?.includeIframes) {
+      const iframeResult = await this.extractIframeContent(
+        page,
+        options,
+        freshIdGenerator,
+        landmarks,
+        headings,
+        elements,
+        forms,
+      );
+
+      if (iframeResult.iframeInfos.length > 0) {
+        iframeInfos = iframeResult.iframeInfos;
+
+        // Merge iframe content summaries
+        if (contentSummary !== undefined && iframeResult.contentSummaries.length > 0) {
+          contentSummary += "; " + iframeResult.contentSummaries.join("; ");
+        }
+        if (fullContent !== undefined && iframeResult.fullContents.length > 0) {
+          fullContent += "\n\n" + iframeResult.fullContents.join("\n\n");
+        }
+
+        // Rebuild interactive summary if needed (now includes iframe elements)
+        if (options.detail === "minimal") {
+          interactiveSummary = this.buildInteractiveSummaryFromElements(elements);
+        }
+      }
+    }
+
+    // Step 10: Atomically replace the shared ID generator
     this.elementIdGenerator.replaceWith(freshIdGenerator);
 
-    // Step 10: Get page metadata
+    // Step 11: Get page metadata
     const url = page.url();
     const title = await page.title();
     const viewport = page.viewport() ?? { width: 1280, height: 720 };
@@ -122,6 +159,7 @@ export class RendererPipeline {
       interactive: elements,
       forms,
       ...(interactiveSummary ? { interactive_summary: interactiveSummary } : {}),
+      ...(iframeInfos ? { iframes: iframeInfos } : {}),
       errors: {
         console: [],
         network: [],
@@ -134,9 +172,157 @@ export class RendererPipeline {
       headings: headings.length,
       interactive: elements.length,
       forms: forms.length,
+      iframes: iframeInfos?.length ?? 0,
     });
 
     return representation;
+  }
+
+  /**
+   * Extract content from all discoverable child frames and merge into the
+   * main-frame arrays (landmarks, headings, elements, forms).
+   */
+  private async extractIframeContent(
+    page: Page,
+    options: RenderOptions,
+    freshIdGenerator: ElementIdGenerator,
+    landmarks: Landmark[],
+    headings: Heading[],
+    elements: ReturnType<InteractiveExtractor["extractInteractiveElements"]>["elements"],
+    forms: ReturnType<InteractiveExtractor["extractInteractiveElements"]>["forms"],
+  ): Promise<{
+    iframeInfos: IframeInfo[];
+    contentSummaries: string[];
+    fullContents: string[];
+  }> {
+    const iframeInfos: IframeInfo[] = [];
+    const contentSummaries: string[] = [];
+    const fullContents: string[] = [];
+
+    const maxDepth = this.config?.iframeDepth ?? 3;
+    let discoveredFrames: DiscoveredFrame[];
+
+    try {
+      discoveredFrames = await discoverFrames(page, this.cdpSessionManager, maxDepth);
+    } catch (error) {
+      logger.debug("Frame discovery failed", error);
+      return { iframeInfos, contentSummaries, fullContents };
+    }
+
+    for (const discoveredFrame of discoveredFrames) {
+      try {
+        await this.extractSingleFrame(
+          discoveredFrame,
+          options,
+          freshIdGenerator,
+          landmarks,
+          headings,
+          elements,
+          forms,
+          contentSummaries,
+          fullContents,
+        );
+
+        iframeInfos.push({
+          frame_id: discoveredFrame.frameId,
+          url: discoveredFrame.url,
+          bounds: discoveredFrame.iframeBounds,
+        });
+      } catch (error) {
+        logger.debug(`Failed to extract iframe content from ${discoveredFrame.url}`, error);
+      }
+    }
+
+    return { iframeInfos, contentSummaries, fullContents };
+  }
+
+  /**
+   * Extract AX tree, layout, landmarks, headings, interactive elements, forms,
+   * and content from a single child frame. Merges results into the provided arrays.
+   */
+  private async extractSingleFrame(
+    discoveredFrame: DiscoveredFrame,
+    options: RenderOptions,
+    freshIdGenerator: ElementIdGenerator,
+    landmarks: Landmark[],
+    headings: Heading[],
+    elements: ReturnType<InteractiveExtractor["extractInteractiveElements"]>["elements"],
+    forms: ReturnType<InteractiveExtractor["extractInteractiveElements"]>["forms"],
+    contentSummaries: string[],
+    fullContents: string[],
+  ): Promise<void> {
+    const { session, frameId, url: frameUrl, contentOffset } = discoveredFrame;
+
+    // Extract AX tree for this frame
+    const frameRootNodes = await this.accessibilityExtractor.extract(session, frameId);
+    if (frameRootNodes.length === 0) return;
+
+    // Collect and extract layout with offset
+    const nodesNeedingBounds = this.collectNodesNeedingBounds(frameRootNodes);
+    const backendNodeIds = nodesNeedingBounds
+      .filter((n) => n.backendDOMNodeId !== null)
+      .map((n) => n.backendDOMNodeId as number);
+
+    const boundsMap = await this.layoutExtractor.getBoundsForNodes(
+      session,
+      backendNodeIds,
+      contentOffset,
+    );
+
+    // Extract landmarks (with frame annotation)
+    const frameLandmarks = this.extractLandmarks(
+      frameRootNodes,
+      boundsMap,
+      freshIdGenerator,
+      frameId,
+    );
+    for (const landmark of frameLandmarks) {
+      landmark.frame = frameUrl;
+      landmarks.push(landmark);
+    }
+
+    // Extract headings (with frame annotation)
+    const frameHeadings = this.extractHeadings(frameRootNodes, freshIdGenerator, frameId);
+    for (const heading of frameHeadings) {
+      heading.frame = frameUrl;
+      headings.push(heading);
+    }
+
+    // Extract interactive elements and forms (with frame annotation)
+    const frameResult = this.interactiveExtractor.extractInteractiveElements(
+      frameRootNodes,
+      boundsMap,
+      freshIdGenerator,
+      frameId,
+    );
+
+    // Reclassify file inputs for this frame
+    await reclassifyFileInputs(frameResult.elements, session, freshIdGenerator);
+
+    for (const element of frameResult.elements) {
+      element.frame = frameUrl;
+      elements.push(element);
+    }
+
+    for (const form of frameResult.forms) {
+      form.frame = frameUrl;
+      forms.push(form);
+    }
+
+    // Extract content
+    if (options.detail !== "minimal") {
+      const frameSummary = this.contentExtractor.extractSummary(frameRootNodes);
+      if (frameSummary) {
+        contentSummaries.push(`iframe (${frameUrl}): ${frameSummary}`);
+      }
+    }
+
+    if (options.detail === "full") {
+      const frameFullContent = this.contentExtractor.extractFullContent(frameRootNodes);
+      if (frameFullContent) {
+        fullContents.push(`--- iframe: ${frameUrl} ---\n${frameFullContent}`);
+      }
+    }
   }
 
   private collectNodesNeedingBounds(rootNodes: ParsedAXNode[]): ParsedAXNode[] {
@@ -185,6 +371,7 @@ export class RendererPipeline {
     rootNodes: ParsedAXNode[],
     boundsMap: Map<number, Bounds>,
     idGenerator: ElementIdGenerator,
+    frameId?: string,
   ): Landmark[] {
     const landmarks: Landmark[] = [];
 
@@ -202,6 +389,7 @@ export class RendererPipeline {
           node.name,
           domPath,
           node.backendDOMNodeId,
+          frameId,
         );
 
         landmarks.push({
@@ -224,7 +412,11 @@ export class RendererPipeline {
     return landmarks;
   }
 
-  private extractHeadings(rootNodes: ParsedAXNode[], idGenerator: ElementIdGenerator): Heading[] {
+  private extractHeadings(
+    rootNodes: ParsedAXNode[],
+    idGenerator: ElementIdGenerator,
+    frameId?: string,
+  ): Heading[] {
     const headings: Heading[] = [];
 
     const traverse = (node: ParsedAXNode) => {
@@ -237,6 +429,7 @@ export class RendererPipeline {
           node.name,
           domPath,
           node.backendDOMNodeId,
+          frameId,
         );
 
         headings.push({
@@ -288,6 +481,32 @@ export class RendererPipeline {
 
     for (const root of rootNodes) {
       traverse(root, PAGE_ROOT_KEY);
+    }
+
+    return { total, by_landmark: landmarkCounts };
+  }
+
+  /**
+   * Build interactive summary from the already-extracted elements array.
+   * Used when iframe elements have been merged in and we need to rebuild
+   * the summary to include them.
+   */
+  private buildInteractiveSummaryFromElements(
+    elements: { type: string; frame?: string }[],
+  ): InteractiveSummary {
+    const PAGE_ROOT_KEY = "(page root)";
+    const IFRAME_KEY = "(iframe)";
+    const landmarkCounts: Record<string, Record<string, number>> = {};
+    let total = 0;
+
+    for (const element of elements) {
+      const landmarkKey = element.frame ? IFRAME_KEY : PAGE_ROOT_KEY;
+      if (!landmarkCounts[landmarkKey]) {
+        landmarkCounts[landmarkKey] = {};
+      }
+      landmarkCounts[landmarkKey][element.type] =
+        (landmarkCounts[landmarkKey][element.type] ?? 0) + 1;
+      total++;
     }
 
     return { total, by_landmark: landmarkCounts };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { BrowserManager } from "./browser/browser-manager.js";
 import type { PageManager } from "./browser/page-manager.js";
+import type { CDPSessionManager } from "./browser/cdp-session.js";
 import type { RendererPipeline } from "./renderer/renderer-pipeline.js";
 import type { ElementIdGenerator } from "./renderer/element-id-generator.js";
 import type { SnapshotStore } from "./state/snapshot-store.js";
@@ -29,6 +30,7 @@ import type { DevModeState } from "./dev/dev-mode-state.js";
 export interface ServerDeps {
   browserManager: BrowserManager;
   pageManager: PageManager;
+  cdpSessionManager: CDPSessionManager;
   rendererPipeline: RendererPipeline;
   elementIdGenerator: ElementIdGenerator;
   snapshotStore: SnapshotStore;
@@ -102,6 +104,7 @@ export function createServer(deps: ServerDeps, options: ServerOptions = {}): Cre
   const toolDeps = {
     browserManager: deps.browserManager,
     pageManager: deps.pageManager,
+    cdpSessionManager: deps.cdpSessionManager,
     rendererPipeline: deps.rendererPipeline,
     elementIdGenerator: deps.elementIdGenerator,
     snapshotStore: deps.snapshotStore,

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -241,9 +241,18 @@ export function registerSessionTools(
           .describe(
             'Auto-dismiss behavior for JS dialogs. "none" (default) queues for charlotte:dialog.',
           ),
+        include_iframes: coercedBoolean
+          .optional()
+          .describe(
+            "Include iframe content in page representations (default: false). Extracts accessibility tree, interactive elements, and content from child frames.",
+          ),
+        iframe_depth: z
+          .number()
+          .optional()
+          .describe("Maximum iframe nesting depth to traverse (default: 3, min: 1, max: 10)"),
       },
     },
-    async ({ snapshot_depth, auto_snapshot, screenshot_dir, dialog_auto_dismiss }) => {
+    async ({ snapshot_depth, auto_snapshot, screenshot_dir, dialog_auto_dismiss, include_iframes, iframe_depth }) => {
       try {
         logger.info("Configuring Charlotte", { snapshot_depth, auto_snapshot, screenshot_dir });
 
@@ -265,6 +274,14 @@ export function registerSessionTools(
           deps.config.dialogAutoDismiss = dialog_auto_dismiss as DialogAutoDismiss;
         }
 
+        if (include_iframes !== undefined) {
+          deps.config.includeIframes = include_iframes;
+        }
+
+        if (iframe_depth !== undefined) {
+          deps.config.iframeDepth = Math.max(1, Math.min(10, iframe_depth));
+        }
+
         return {
           content: [
             {
@@ -276,6 +293,8 @@ export function registerSessionTools(
                   auto_snapshot: deps.config.autoSnapshot,
                   screenshot_dir: deps.artifactStore.screenshotDir,
                   dialog_auto_dismiss: deps.config.dialogAutoDismiss,
+                  include_iframes: deps.config.includeIframes,
+                  iframe_depth: deps.config.iframeDepth,
                 },
               }),
             },

--- a/src/tools/tool-helpers.ts
+++ b/src/tools/tool-helpers.ts
@@ -1,6 +1,7 @@
-import type { Page } from "puppeteer";
+import type { Page, CDPSession } from "puppeteer";
 import type { PageManager } from "../browser/page-manager.js";
 import type { BrowserManager } from "../browser/browser-manager.js";
+import type { CDPSessionManager } from "../browser/cdp-session.js";
 import type { RendererPipeline } from "../renderer/renderer-pipeline.js";
 import type { ElementIdGenerator } from "../renderer/element-id-generator.js";
 import type { SnapshotStore } from "../state/snapshot-store.js";
@@ -12,6 +13,7 @@ import type { DetailLevel } from "../renderer/renderer-pipeline.js";
 import { z } from "zod";
 import { CharlotteError, CharlotteErrorCode } from "../types/errors.js";
 import { diffRepresentations } from "../state/differ.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * Boolean schema that accepts both native booleans and string representations
@@ -26,6 +28,7 @@ export const coercedBoolean = z.preprocess(
 export interface ToolDependencies {
   browserManager: BrowserManager;
   pageManager: PageManager;
+  cdpSessionManager: CDPSessionManager;
   rendererPipeline: RendererPipeline;
   elementIdGenerator: ElementIdGenerator;
   snapshotStore: SnapshotStore;
@@ -121,6 +124,13 @@ export async function renderActivePage(
   return representation;
 }
 
+export interface ResolvedElement {
+  page: Page;
+  backendNodeId: number;
+  /** CDP frame ID if the element is in an iframe, null for main frame. */
+  frameId: string | null;
+}
+
 /**
  * Resolve an element ID to a Puppeteer ElementHandle via CDP backend node ID.
  * If the ID is stale (not found after re-render), throws ELEMENT_NOT_FOUND
@@ -129,20 +139,22 @@ export async function renderActivePage(
 export async function resolveElement(
   deps: ToolDependencies,
   elementId: string,
-): Promise<{ page: Page; backendNodeId: number }> {
+): Promise<ResolvedElement> {
   const page = deps.pageManager.getActivePage();
 
   // Step 1: Check current map
   let backendNodeId = deps.elementIdGenerator.resolveId(elementId);
   if (backendNodeId !== null) {
-    return { page, backendNodeId };
+    const frameId = deps.elementIdGenerator.resolveFrame(elementId);
+    return { page, backendNodeId, frameId };
   }
 
   // Step 2: Re-render and check again (map was invalidated)
   const freshRepresentation = await renderActivePage(deps, { detail: "minimal" });
   backendNodeId = deps.elementIdGenerator.resolveId(elementId);
   if (backendNodeId !== null) {
-    return { page, backendNodeId };
+    const frameId = deps.elementIdGenerator.resolveFrame(elementId);
+    return { page, backendNodeId, frameId };
   }
 
   // Step 3: Element is genuinely gone — suggest similar
@@ -157,6 +169,29 @@ export async function resolveElement(
     `Element '${elementId}' not found on page.`,
     suggestion,
   );
+}
+
+/**
+ * Get the appropriate CDP session for an element.
+ * Returns the frame-specific session for iframe elements, or the main page session.
+ */
+export async function getSessionForElement(
+  deps: ToolDependencies,
+  resolved: ResolvedElement,
+): Promise<CDPSession> {
+  if (resolved.frameId) {
+    // Find the frame by ID and get its session
+    const allFrames = resolved.page.frames();
+    const targetFrame = allFrames.find(
+      (f) => deps.cdpSessionManager.getFrameId(f) === resolved.frameId,
+    );
+    if (targetFrame) {
+      return deps.cdpSessionManager.getFrameSession(targetFrame);
+    }
+    // Fallback to main session if frame not found (frame may have navigated away)
+    logger.warn(`Frame ${resolved.frameId} not found, falling back to main session`);
+  }
+  return deps.cdpSessionManager.getSession(resolved.page);
 }
 
 /**
@@ -230,6 +265,11 @@ export function stripEmptyFields(representation: PageRepresentation): Record<str
     }
 
     cleaned.structure = structure;
+  }
+
+  // Strip empty iframes
+  if (!representation.iframes || representation.iframes.length === 0) {
+    delete cleaned.iframes;
   }
 
   // Strip absent pending_dialog

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,10 @@ export interface CharlotteConfig {
   dialogAutoDismiss: DialogAutoDismiss;
   /** Directory for persistent screenshot artifacts. Defaults to OS temp dir. */
   screenshotDir?: string;
+  /** Whether to include iframe content in page representations. Default: false. */
+  includeIframes: boolean;
+  /** Maximum iframe nesting depth to traverse. Default: 3. */
+  iframeDepth: number;
 }
 
 export function createDefaultConfig(): CharlotteConfig {
@@ -17,5 +21,7 @@ export function createDefaultConfig(): CharlotteConfig {
     autoSnapshot: "every_action",
     dialogAutoDismiss: "none",
     allowedWorkspaceRoot: process.cwd(), // Default to cwd for universal safety
+    includeIframes: false,
+    iframeDepth: 3,
   };
 }

--- a/src/types/page-representation.ts
+++ b/src/types/page-representation.ts
@@ -10,12 +10,16 @@ export interface Landmark {
   role: string;
   label: string;
   bounds: Bounds;
+  /** Source frame URL. Omitted for main frame. */
+  frame?: string;
 }
 
 export interface Heading {
   level: 1 | 2 | 3 | 4 | 5 | 6;
   text: string;
   id: string;
+  /** Source frame URL. Omitted for main frame. */
+  frame?: string;
 }
 
 export interface ElementState {
@@ -53,6 +57,8 @@ export interface InteractiveElement {
   placeholder?: string;
   value?: string;
   options?: string[];
+  /** Source frame URL. Omitted for main frame. */
+  frame?: string;
 }
 
 export interface FormRepresentation {
@@ -61,6 +67,8 @@ export interface FormRepresentation {
   method?: string;
   fields: string[];
   submit: string | null;
+  /** Source frame URL. Omitted for main frame. */
+  frame?: string;
 }
 
 export interface PageStructure {
@@ -91,6 +99,12 @@ export interface PendingDialog {
   timestamp: string; // ISO 8601
 }
 
+export interface IframeInfo {
+  frame_id: string;
+  url: string;
+  bounds: Bounds | null;
+}
+
 export interface PageRepresentation {
   url: string;
   title: string;
@@ -105,6 +119,7 @@ export interface PageRepresentation {
     network: Array<{ url: string; status: number; statusText: string }>;
   };
   interactive_summary?: InteractiveSummary;
+  iframes?: IframeInfo[];
   reload_event?: ReloadEvent;
   pending_dialog?: PendingDialog;
   delta?: import("./snapshot.js").SnapshotDiff;

--- a/tests/fixtures/pages/iframe-child.html
+++ b/tests/fixtures/pages/iframe-child.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Iframe Child</title>
+</head>
+<body>
+  <main>
+    <h1>Iframe Content</h1>
+    <p>This is content inside an iframe.</p>
+    <a href="https://example.com">Iframe Link</a>
+    <button id="iframe-btn">Iframe Button</button>
+    <form>
+      <label for="iframe-input">Iframe Input</label>
+      <input type="text" id="iframe-input" name="iframe-input">
+    </form>
+    <iframe src="iframe-grandchild.html" width="400" height="200" title="Nested Iframe"></iframe>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/pages/iframe-grandchild.html
+++ b/tests/fixtures/pages/iframe-grandchild.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Iframe Grandchild</title>
+</head>
+<body>
+  <main>
+    <h2>Nested Iframe Content</h2>
+    <p>This is content inside a nested iframe.</p>
+    <button id="nested-btn">Nested Button</button>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/pages/iframe-parent.html
+++ b/tests/fixtures/pages/iframe-parent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Iframe Parent</title>
+</head>
+<body>
+  <header>
+    <h1>Parent Page</h1>
+    <nav>
+      <a href="https://example.com">Parent Link</a>
+    </nav>
+  </header>
+  <main>
+    <p>Main page content above the iframe.</p>
+    <iframe src="iframe-child.html" width="600" height="400" title="Test Iframe"></iframe>
+  </main>
+</body>
+</html>

--- a/tests/integration/dev-mode.test.ts
+++ b/tests/integration/dev-mode.test.ts
@@ -55,6 +55,7 @@ describe("Dev mode integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),
@@ -79,6 +80,7 @@ describe("Dev mode integration", () => {
         directoryPath: FIXTURES_DIR,
         watch: false,
         pageManager,
+        cdpSessionManager,
       });
 
       expect(serverInfo.url).toMatch(/^http:\/\/localhost:\d+$/);
@@ -105,6 +107,7 @@ describe("Dev mode integration", () => {
         directoryPath: FIXTURES_DIR,
         watch: false,
         pageManager,
+        cdpSessionManager,
       });
 
       expect(serverInfo.port).toBeGreaterThan(0);
@@ -121,12 +124,14 @@ describe("Dev mode integration", () => {
         directoryPath: FIXTURES_DIR,
         watch: false,
         pageManager,
+        cdpSessionManager,
       });
 
       const secondInfo = await devModeState.startServing({
         directoryPath: FIXTURES_DIR,
         watch: false,
         pageManager,
+        cdpSessionManager,
       });
 
       // First server should be stopped
@@ -345,6 +350,7 @@ describe("Dev mode integration", () => {
           directoryPath: tempServDir,
           watch: true,
           pageManager,
+          cdpSessionManager,
           usePolling: true,
         });
 

--- a/tests/integration/dialog.test.ts
+++ b/tests/integration/dialog.test.ts
@@ -48,6 +48,7 @@ describe("Dialog integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),
@@ -385,6 +386,7 @@ describe("Dialog integration", () => {
         {
           browserManager: deps.browserManager,
           pageManager: deps.pageManager,
+          cdpSessionManager,
           rendererPipeline: deps.rendererPipeline,
           elementIdGenerator: deps.elementIdGenerator,
           snapshotStore: deps.snapshotStore,

--- a/tests/integration/drag.test.ts
+++ b/tests/integration/drag.test.ts
@@ -38,6 +38,7 @@ describe("Drag and drop integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/iframe.test.ts
+++ b/tests/integration/iframe.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as path from "node:path";
+import * as os from "node:os";
+import { BrowserManager } from "../../src/browser/browser-manager.js";
+import { PageManager } from "../../src/browser/page-manager.js";
+import { CDPSessionManager } from "../../src/browser/cdp-session.js";
+import { RendererPipeline } from "../../src/renderer/renderer-pipeline.js";
+import { ElementIdGenerator } from "../../src/renderer/element-id-generator.js";
+import { SnapshotStore } from "../../src/state/snapshot-store.js";
+import { ArtifactStore } from "../../src/state/artifact-store.js";
+import { createDefaultConfig } from "../../src/types/config.js";
+import { StaticServer } from "../../src/dev/static-server.js";
+import type { ToolDependencies } from "../../src/tools/tool-helpers.js";
+import { renderActivePage, resolveElement } from "../../src/tools/tool-helpers.js";
+
+const FIXTURES_DIR = path.resolve(import.meta.dirname, "../fixtures/pages");
+
+describe("Iframe content extraction", () => {
+  let browserManager: BrowserManager;
+  let pageManager: PageManager;
+  let cdpSessionManager: CDPSessionManager;
+  let elementIdGenerator: ElementIdGenerator;
+  let deps: ToolDependencies;
+  let staticServer: StaticServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    // Serve fixtures over HTTP (iframes need HTTP, not file://)
+    staticServer = new StaticServer();
+    const serverInfo = await staticServer.start({ directoryPath: FIXTURES_DIR });
+    baseUrl = serverInfo.url;
+
+    browserManager = new BrowserManager();
+    await browserManager.launch();
+    pageManager = new PageManager();
+    await pageManager.openTab(browserManager);
+    cdpSessionManager = new CDPSessionManager();
+    elementIdGenerator = new ElementIdGenerator();
+
+    const config = createDefaultConfig();
+    config.includeIframes = true;
+    config.iframeDepth = 3;
+
+    const rendererPipeline = new RendererPipeline(
+      cdpSessionManager,
+      elementIdGenerator,
+      config,
+    );
+    const artifactStore = new ArtifactStore(
+      path.join(os.tmpdir(), "charlotte-iframe-test-artifacts"),
+    );
+    await artifactStore.initialize();
+
+    deps = {
+      browserManager,
+      pageManager,
+      cdpSessionManager,
+      rendererPipeline,
+      elementIdGenerator,
+      snapshotStore: new SnapshotStore(config.snapshotDepth),
+      artifactStore,
+      config,
+    };
+  });
+
+  afterAll(async () => {
+    await browserManager.close();
+    await staticServer.stop();
+  });
+
+  it("extracts iframe content when includeIframes is enabled", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    // Main frame content should be present
+    expect(representation.title).toBe("Iframe Parent");
+    expect(representation.structure.headings.some((h) => h.text === "Parent Page")).toBe(true);
+
+    // Iframe content should be merged in
+    const iframeHeading = representation.structure.headings.find(
+      (h) => h.text === "Iframe Content",
+    );
+    expect(iframeHeading).toBeDefined();
+    expect(iframeHeading!.frame).toContain("iframe-child.html");
+
+    // Iframe interactive elements should be present
+    const iframeButton = representation.interactive.find((el) => el.label === "Iframe Button");
+    expect(iframeButton).toBeDefined();
+    expect(iframeButton!.frame).toContain("iframe-child.html");
+
+    const iframeLink = representation.interactive.find((el) => el.label === "Iframe Link");
+    expect(iframeLink).toBeDefined();
+    expect(iframeLink!.frame).toContain("iframe-child.html");
+
+    // Main frame elements should NOT have frame annotation
+    const parentLink = representation.interactive.find((el) => el.label === "Parent Link");
+    expect(parentLink).toBeDefined();
+    expect(parentLink!.frame).toBeUndefined();
+
+    // iframes metadata should include both child and grandchild
+    expect(representation.iframes).toBeDefined();
+    expect(representation.iframes!.length).toBe(2);
+    expect(representation.iframes![0].url).toContain("iframe-child.html");
+    expect(representation.iframes![0].bounds).toBeDefined();
+    expect(representation.iframes![1].url).toContain("iframe-grandchild.html");
+  });
+
+  it("iframe elements have page-level bounds (offset by iframe position)", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    const iframeInfo = representation.iframes![0];
+    const iframeButton = representation.interactive.find((el) => el.label === "Iframe Button");
+
+    // The iframe button's bounds should be offset by the iframe's position
+    // (its page-level x/y should be >= the iframe element's x/y)
+    if (iframeInfo.bounds && iframeButton?.bounds) {
+      expect(iframeButton.bounds.x).toBeGreaterThanOrEqual(iframeInfo.bounds.x);
+      expect(iframeButton.bounds.y).toBeGreaterThanOrEqual(iframeInfo.bounds.y);
+    }
+  });
+
+  it("iframe element IDs are resolvable via resolveElement", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    const iframeButton = representation.interactive.find((el) => el.label === "Iframe Button");
+    expect(iframeButton).toBeDefined();
+
+    // resolveElement should succeed for iframe elements
+    const resolved = await resolveElement(deps, iframeButton!.id);
+    expect(resolved.backendNodeId).toBeDefined();
+    expect(resolved.frameId).toBeTruthy();
+  });
+
+  it("does not extract iframes when includeIframes is disabled", async () => {
+    // Temporarily disable
+    deps.config.includeIframes = false;
+
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    // Should only have main frame content
+    expect(representation.structure.headings.every((h) => !h.frame)).toBe(true);
+    expect(representation.interactive.every((el) => !el.frame)).toBe(true);
+    expect(representation.iframes).toBeUndefined();
+
+    // Re-enable for subsequent tests
+    deps.config.includeIframes = true;
+  });
+
+  it("includes iframe content in full content extraction", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "full" });
+
+    expect(representation.structure.full_content).toBeDefined();
+    expect(representation.structure.full_content).toContain("iframe-child.html");
+    expect(representation.structure.full_content).toContain("This is content inside an iframe.");
+  });
+
+  it("includes iframe content in content summary", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    expect(representation.structure.content_summary).toBeDefined();
+    expect(representation.structure.content_summary).toContain("iframe");
+  });
+
+  it("extracts nested iframes (depth > 1)", async () => {
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    // Grandchild iframe heading should be present
+    const nestedHeading = representation.structure.headings.find(
+      (h) => h.text === "Nested Iframe Content",
+    );
+    expect(nestedHeading).toBeDefined();
+    expect(nestedHeading!.frame).toContain("iframe-grandchild.html");
+
+    // Grandchild interactive element should be present
+    const nestedButton = representation.interactive.find((el) => el.label === "Nested Button");
+    expect(nestedButton).toBeDefined();
+    expect(nestedButton!.frame).toContain("iframe-grandchild.html");
+  });
+
+  it("respects iframeDepth limit", async () => {
+    // Set depth to 1 — should get child but not grandchild
+    deps.config.iframeDepth = 1;
+
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+    const representation = await renderActivePage(deps, { detail: "summary" });
+
+    // Child iframe content should be present
+    const childHeading = representation.structure.headings.find(
+      (h) => h.text === "Iframe Content",
+    );
+    expect(childHeading).toBeDefined();
+
+    // Grandchild iframe content should NOT be present
+    const nestedHeading = representation.structure.headings.find(
+      (h) => h.text === "Nested Iframe Content",
+    );
+    expect(nestedHeading).toBeUndefined();
+
+    // Only 1 iframe should be discovered
+    expect(representation.iframes).toBeDefined();
+    expect(representation.iframes!.length).toBe(1);
+    expect(representation.iframes![0].url).toContain("iframe-child.html");
+
+    // Restore depth for subsequent tests
+    deps.config.iframeDepth = 3;
+  });
+});

--- a/tests/integration/interaction.test.ts
+++ b/tests/integration/interaction.test.ts
@@ -40,6 +40,7 @@ describe("Interaction integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/keyboard.test.ts
+++ b/tests/integration/keyboard.test.ts
@@ -37,6 +37,7 @@ describe("Keyboard integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/modifier-click.test.ts
+++ b/tests/integration/modifier-click.test.ts
@@ -38,6 +38,7 @@ describe("Modifier click integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/navigation.test.ts
+++ b/tests/integration/navigation.test.ts
@@ -38,6 +38,7 @@ describe("Navigation integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/observation.test.ts
+++ b/tests/integration/observation.test.ts
@@ -43,6 +43,7 @@ describe("Observation integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/screenshot-artifacts.test.ts
+++ b/tests/integration/screenshot-artifacts.test.ts
@@ -39,6 +39,7 @@ describe("Screenshot artifacts integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/session.test.ts
+++ b/tests/integration/session.test.ts
@@ -37,6 +37,7 @@ describe("Session integration", () => {
     _deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/state.test.ts
+++ b/tests/integration/state.test.ts
@@ -40,6 +40,7 @@ describe("State management integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/integration/tabs-viewport-network.test.ts
+++ b/tests/integration/tabs-viewport-network.test.ts
@@ -37,6 +37,7 @@ describe("Tabs, viewport, and network integration", () => {
     deps = {
       browserManager,
       pageManager,
+      cdpSessionManager,
       rendererPipeline,
       elementIdGenerator,
       snapshotStore: new SnapshotStore(config.snapshotDepth),

--- a/tests/unit/tools/create-server.test.ts
+++ b/tests/unit/tools/create-server.test.ts
@@ -10,6 +10,7 @@ function createMockDeps(): ServerDeps {
   return {
     browserManager: {} as any,
     pageManager: { getActivePage: () => ({}) } as any,
+    cdpSessionManager: {} as any,
     rendererPipeline: {} as any,
     elementIdGenerator: {} as any,
     snapshotStore: {} as any,
@@ -20,6 +21,8 @@ function createMockDeps(): ServerDeps {
       screenshotDir: "/tmp",
       dialogAutoDismiss: "none",
       allowedWorkspaceRoot: "/tmp",
+      includeIframes: false,
+      iframeDepth: 3,
     } as any,
   };
 }


### PR DESCRIPTION
## Summary
- Adds iframe content extraction to the renderer pipeline, resolving #23
- Gated behind `config.includeIframes` (default `false`), configurable via `charlotte:configure`
- Discovers child frames recursively via CDP, extracts AX trees, and merges landmarks, headings, interactive elements, forms, and content into the main `PageRepresentation` with `frame` URL annotations
- Element bounds are translated to page-level coordinates via iframe offset
- Element IDs include frame context to prevent cross-frame hash collisions
- `getSessionForElement()` added for frame-aware CDP session resolution (interaction tool wiring is a follow-up)

## Known limitations (follow-up work)
- **Interaction tools don't yet use frame sessions** — iframe elements are observable but not yet interactable (click/type/hover use `page.createCDPSession()` which targets the main frame). `getSessionForElement()` is ready but needs to be wired into interaction helpers.
- **Frame session cleanup** — `CDPSessionManager.frameSessions` grows but isn't pruned on navigation
- **Interactive summary loses landmark context** — `buildInteractiveSummaryFromElements` groups iframe elements under `(iframe)` instead of preserving per-landmark breakdown

## Test plan
- [x] 8 integration tests covering: extraction, bounds offset, element resolution, opt-out, full content, content summary, nested iframes (depth > 1), depth limit enforcement
- [x] All 920 tests pass (no regressions)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

// ticktockbent