### PR TITLE
Fix wait_for JS eval to use CDP Runtime.evaluate

### DIFF
--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -1125,15 +1125,23 @@ async function pollWaitForCondition(
       if (!selectorMatched) allSatisfied = false;
     }
 
-    // Check JS condition
+    // Check JS condition via CDP Runtime.evaluate (matches evaluate.ts pattern)
     if (allSatisfied && condition.js) {
+      const cdpSession = await page.createCDPSession();
       try {
-        const jsResult = await page.evaluate((expression) => {
-          return !!new Function("return " + expression)();
-        }, condition.js);
-        if (!jsResult) allSatisfied = false;
+        const evalResult = await cdpSession.send("Runtime.evaluate", {
+          expression: condition.js,
+          returnByValue: true,
+          awaitPromise: true,
+          timeout: Math.max(0, deadline - Date.now()),
+        });
+        const isTruthy =
+          !evalResult.exceptionDetails && !!evalResult.result.value;
+        if (!isTruthy) allSatisfied = false;
       } catch {
         allSatisfied = false;
+      } finally {
+        await cdpSession.detach().catch(() => {});
       }
     }
 


### PR DESCRIPTION
## Summary
- Replaces `new Function("return " + expr)` in `wait_for`'s JS condition check with CDP `Runtime.evaluate`, matching the pattern already used by `charlotte:evaluate`
- Fixes multi-statement JS conditions silently returning `undefined` due to ASI (`return\n` → `return;`)
- Adds `awaitPromise: true` so async JS conditions work correctly

Closes #73

## Test plan
- [x] All 503 existing tests pass (39 files — 261 unit + 242 integration)
- [x] Existing `wait_for` JS condition integration test passes with new implementation
- [x] TypeScript type check clean (`npx tsc --noEmit`)

// ticktockbent