### PR TITLE
Fix browser reconnection race in getBrowser()

### DIFF
--- a/src/browser/browser-manager.ts
+++ b/src/browser/browser-manager.ts
@@ -44,6 +44,13 @@ export class BrowserManager {
     // Prevent concurrent relaunch attempts
     if (this.launching) {
       await this.launching;
+      // Verify the concurrent launch actually succeeded
+      if (!this.browser || !this.browser.connected) {
+        throw new CharlotteError(
+          CharlotteErrorCode.SESSION_ERROR,
+          "Browser launch failed during concurrent reconnection attempt.",
+        );
+      }
       return;
     }
 
@@ -64,19 +71,19 @@ export class BrowserManager {
     }
   }
 
-  getBrowser(): Browser {
+  async getBrowser(): Promise<Browser> {
+    await this.ensureConnected();
     if (!this.browser || !this.browser.connected) {
       throw new CharlotteError(
         CharlotteErrorCode.SESSION_ERROR,
-        "Browser is not connected. Call ensureConnected() first.",
+        "Browser is not connected after ensureConnected().",
       );
     }
     return this.browser;
   }
 
   async newPage(): Promise<Page> {
-    await this.ensureConnected();
-    const browser = this.getBrowser();
+    const browser = await this.getBrowser();
     return browser.newPage();
   }
 


### PR DESCRIPTION
## Summary
- `getBrowser()` now calls `ensureConnected()` to auto-recover instead of throwing `SESSION_ERROR` immediately when the browser has disconnected between calls
- `ensureConnected()` now verifies browser health after awaiting a concurrent launch (catches failed reconnection attempts that previously returned silently)
- `getBrowser()` signature changes from sync to async — only internal caller is `newPage()` which is already async

Closes #83

## Test plan
- [x] All 503 tests pass (39 files — 261 unit + 242 integration)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] No external callers of `getBrowser()` — only used internally by `newPage()`

// ticktockbent