### PR TITLE
Add error resilience to renderer pipeline

### DIFF
--- a/src/renderer/accessibility-extractor.ts
+++ b/src/renderer/accessibility-extractor.ts
@@ -79,7 +79,9 @@ function extractProperties(
   if (!rawProperties) return properties;
 
   for (const prop of rawProperties) {
-    properties[prop.name] = prop.value.value;
+    if (prop.value?.value !== undefined) {
+      properties[prop.name] = prop.value.value;
+    }
   }
   return properties;
 }

--- a/src/renderer/content-extractor.ts
+++ b/src/renderer/content-extractor.ts
@@ -1,5 +1,6 @@
 import type { ParsedAXNode } from "./accessibility-extractor.js";
 import { isLandmarkRole } from "./accessibility-extractor.js";
+import { logger } from "../utils/logger.js";
 
 interface LandmarkCounts {
   role: string;
@@ -160,7 +161,11 @@ export class ContentExtractor {
     };
 
     for (const root of rootNodes) {
-      traverse(root);
+      try {
+        traverse(root);
+      } catch (error) {
+        logger.warn("Skipping malformed AX node during content extraction", error);
+      }
     }
 
     return textParts.join("\n");

--- a/src/renderer/frame-discovery.ts
+++ b/src/renderer/frame-discovery.ts
@@ -103,15 +103,19 @@ async function traverseFrames(
       });
 
       // Recurse into nested iframes
-      await traverseFrames(
-        childFrame,
-        frameSession,
-        cdpSessionManager,
-        contentOffset,
-        currentDepth + 1,
-        maxDepth,
-        discovered,
-      );
+      try {
+        await traverseFrames(
+          childFrame,
+          frameSession,
+          cdpSessionManager,
+          contentOffset,
+          currentDepth + 1,
+          maxDepth,
+          discovered,
+        );
+      } catch (error) {
+        logger.debug(`Failed to traverse nested frames in ${frameUrl}`, error);
+      }
     } catch (error) {
       logger.debug(`Failed to discover frame ${frameUrl}`, error);
     }

--- a/src/renderer/layout-extractor.ts
+++ b/src/renderer/layout-extractor.ts
@@ -46,12 +46,19 @@ export class LayoutExtractor {
     const batchSize = 50;
     for (let i = 0; i < backendNodeIds.length; i += batchSize) {
       const batch = backendNodeIds.slice(i, i + batchSize);
-      const results = await Promise.all(
+      const settledResults = await Promise.allSettled(
         batch.map(async (nodeId) => {
           const bounds = await this.getBounds(session, nodeId);
           return { nodeId, bounds };
         }),
       );
+
+      const results = settledResults
+        .filter(
+          (r): r is PromiseFulfilledResult<{ nodeId: number; bounds: Bounds | null }> =>
+            r.status === "fulfilled",
+        )
+        .map((r) => r.value);
 
       for (const { nodeId, bounds } of results) {
         if (bounds && (offsetX !== 0 || offsetY !== 0)) {


### PR DESCRIPTION
## Summary
- **#86**: Guard `prop.value?.value` in accessibility extractor to prevent crash on malformed AX properties
- **#79**: Wrap per-root-node content extraction in try/catch — a single bad node no longer crashes the entire render
- **#74**: Wrap recursive `traverseFrames()` call in try/catch — one bad iframe no longer aborts discovery of remaining frames
- **#77**: Use `Promise.allSettled()` in batch layout extraction — a transient CDP session error no longer discards the entire batch

Closes #79, closes #74, closes #77, closes #86

## Test plan
- [x] All 503 tests pass (39 files — 261 unit + 242 integration)
- [x] TypeScript type check clean (`npx tsc --noEmit`)

// ticktockbent