### PR TITLE
Fix event listener cleanup and lifecycle error handling

### DIFF
--- a/src/browser/page-manager.ts
+++ b/src/browser/page-manager.ts
@@ -98,32 +98,36 @@ export class PageManager {
 
     // Handle JavaScript dialogs (alert, confirm, prompt, beforeunload)
     page.on("dialog", async (dialog) => {
-      const dialogType = dialog.type() as PendingDialog["type"];
-      const autoDismiss = this.config.dialogAutoDismiss;
+      try {
+        const dialogType = dialog.type() as PendingDialog["type"];
+        const autoDismiss = this.config.dialogAutoDismiss;
 
-      logger.info("Dialog appeared", { tabId, type: dialogType, message: dialog.message() });
+        logger.info("Dialog appeared", { tabId, type: dialogType, message: dialog.message() });
 
-      // Auto-dismiss logic
-      if (
-        autoDismiss === "accept_all" ||
-        (autoDismiss === "accept_alerts" && dialogType === "alert")
-      ) {
-        await dialog.accept();
-        return;
+        // Auto-dismiss logic
+        if (
+          autoDismiss === "accept_all" ||
+          (autoDismiss === "accept_alerts" && dialogType === "alert")
+        ) {
+          await dialog.accept();
+          return;
+        }
+        if (autoDismiss === "dismiss_all") {
+          await dialog.dismiss();
+          return;
+        }
+
+        // Queue for manual handling
+        managedPage.pendingDialog = dialog;
+        managedPage.pendingDialogInfo = {
+          type: dialogType,
+          message: dialog.message(),
+          ...(dialogType === "prompt" ? { default_value: dialog.defaultValue() } : {}),
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        logger.warn("Dialog handler failed", { tabId, error });
       }
-      if (autoDismiss === "dismiss_all") {
-        await dialog.dismiss();
-        return;
-      }
-
-      // Queue for manual handling
-      managedPage.pendingDialog = dialog;
-      managedPage.pendingDialogInfo = {
-        type: dialogType,
-        message: dialog.message(),
-        ...(dialogType === "prompt" ? { default_value: dialog.defaultValue() } : {}),
-        timestamp: new Date().toISOString(),
-      };
     });
 
     // Clear stale dialog references on main-frame navigation only.
@@ -163,6 +167,10 @@ export class PageManager {
       throw new CharlotteError(CharlotteErrorCode.SESSION_ERROR, `Tab '${tabId}' not found`);
     }
 
+    managedPage.page.removeAllListeners("console");
+    managedPage.page.removeAllListeners("response");
+    managedPage.page.removeAllListeners("dialog");
+    managedPage.page.removeAllListeners("framenavigated");
     await managedPage.page.close();
     this.pages.delete(tabId);
 

--- a/src/dev/dev-mode-state.ts
+++ b/src/dev/dev-mode-state.ts
@@ -50,11 +50,19 @@ export class DevModeState {
   }
 
   async stopAll(): Promise<void> {
-    if (this.fileWatcher.isWatching()) {
-      await this.fileWatcher.stop();
+    try {
+      if (this.fileWatcher.isWatching()) {
+        await this.fileWatcher.stop();
+      }
+    } catch (error) {
+      logger.warn("File watcher stop failed during shutdown", error);
     }
-    if (this.staticServer.isRunning()) {
-      await this.staticServer.stop();
+    try {
+      if (this.staticServer.isRunning()) {
+        await this.staticServer.stop();
+      }
+    } catch (error) {
+      logger.warn("Static server stop failed during shutdown", error);
     }
     this.pendingReloadEvent = null;
     this.reloadInProgress = null;


### PR DESCRIPTION
## Summary
- **#75**: Wrap dialog event handler in try/catch to prevent unhandled promise rejections when a dialog is already dismissed or the page has navigated away
- **#89**: Explicitly `removeAllListeners()` for console, response, dialog, and framenavigated before `page.close()` in `closeTab()` to prevent listener accumulation across tab cycles
- **#80**: Wrap each substep of `DevModeState.stopAll()` in individual try/catch so a file watcher or static server failure doesn't block browser cleanup

Closes #75, closes #89, closes #80

## Test plan
- [x] All 503 tests pass (39 files — 261 unit + 242 integration)
- [x] TypeScript type check clean (`npx tsc --noEmit`)

// ticktockbent