### PR TITLE
Fix null guards, CLI arg parsing, Zod validation, and test cleanup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,10 +34,12 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): {
     logger.warn("Both --profile and --tools provided; --profile takes precedence");
   }
 
-  const outputDir = outputDirArg ? outputDirArg.split("=")[1] : undefined;
+  const outputDir = outputDirArg
+    ? outputDirArg.substring(outputDirArg.indexOf("=") + 1)
+    : undefined;
 
   if (profileArg) {
-    const profile = profileArg.split("=")[1] as ToolProfile;
+    const profile = profileArg.substring(profileArg.indexOf("=") + 1) as ToolProfile;
     if (!VALID_PROFILES.includes(profile)) {
       throw new Error(`Invalid profile: ${profile}. Valid profiles: ${VALID_PROFILES.join(", ")}`);
     }
@@ -45,7 +47,9 @@ export function parseCliArgs(argv: string[] = process.argv.slice(2)): {
   }
 
   if (toolsArg) {
-    const groups = toolsArg.split("=")[1].split(",") as ToolGroupName[];
+    const groups = toolsArg
+      .substring(toolsArg.indexOf("=") + 1)
+      .split(",") as ToolGroupName[];
     for (const group of groups) {
       if (!VALID_GROUPS.includes(group)) {
         throw new Error(`Invalid tool group: ${group}. Valid groups: ${VALID_GROUPS.join(", ")}`);

--- a/src/renderer/interactive-extractor.ts
+++ b/src/renderer/interactive-extractor.ts
@@ -199,6 +199,7 @@ export class InteractiveExtractor {
           const matchingElement = interactiveElements.find((el) => {
             if (node.backendDOMNodeId === null) return false;
             const resolvedId = idGenerator.resolveId(el.id);
+            if (resolvedId === null) return false;
             return resolvedId === node.backendDOMNodeId;
           });
 

--- a/src/renderer/renderer-pipeline.ts
+++ b/src/renderer/renderer-pipeline.ts
@@ -72,8 +72,8 @@ export class RendererPipeline {
     // Step 4: Build a fresh ID generator for this render
     const freshIdGenerator = new ElementIdGenerator();
 
-    // Step 5: Extract landmarks with bounds
-    const landmarks = this.extractLandmarks(rootNodes, boundsMap, freshIdGenerator);
+    // Step 5: Extract landmarks with bounds (pass "main" frameId for consistent hash input)
+    const landmarks = this.extractLandmarks(rootNodes, boundsMap, freshIdGenerator, "main");
 
     // Step 6: Extract headings
     const headings = this.extractHeadings(rootNodes, freshIdGenerator);

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -891,6 +891,7 @@ export function registerInteractionTools(
           ),
         delay: z
           .number()
+          .min(0)
           .optional()
           .describe(
             "Milliseconds between key presses in a sequence (default: 0). Only valid with keys.",

--- a/src/tools/observation.ts
+++ b/src/tools/observation.ts
@@ -381,7 +381,7 @@ export function registerObservationTools(
           .enum(["png", "jpeg", "webp"])
           .optional()
           .describe('"png" (default), "jpeg", "webp"'),
-        quality: z.number().optional().describe("1-100 for jpeg/webp quality"),
+        quality: z.number().min(1).max(100).optional().describe("1-100 for jpeg/webp quality"),
         save: z
           .boolean()
           .optional()

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -469,8 +469,8 @@ export function registerSessionTools(
       description:
         "Change the browser viewport dimensions. Use a device preset or specify custom width/height. Returns page representation at the new viewport size.",
       inputSchema: {
-        width: z.number().optional().describe("Viewport width in pixels"),
-        height: z.number().optional().describe("Viewport height in pixels"),
+        width: z.number().min(1).optional().describe("Viewport width in pixels"),
+        height: z.number().min(1).optional().describe("Viewport height in pixels"),
         device: z
           .enum(["mobile", "tablet", "desktop"])
           .optional()

--- a/tests/integration/file-output.test.ts
+++ b/tests/integration/file-output.test.ts
@@ -29,6 +29,7 @@ describe("File output integration", () => {
   let elementIdGenerator: ElementIdGenerator;
   let deps: ToolDependencies;
   let outputDir: string;
+  let artifactStoreDir: string;
 
   beforeAll(async () => {
     browserManager = new BrowserManager();
@@ -39,11 +40,12 @@ describe("File output integration", () => {
     elementIdGenerator = new ElementIdGenerator();
     rendererPipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator);
     outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "charlotte-file-output-test-"));
+    artifactStoreDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "charlotte-file-output-test-artifacts-"),
+    );
     const config = createDefaultConfig();
     config.outputDir = outputDir;
-    const artifactStore = new ArtifactStore(
-      path.join(os.tmpdir(), "charlotte-file-output-test-artifacts"),
-    );
+    const artifactStore = new ArtifactStore(artifactStoreDir);
     await artifactStore.initialize();
     deps = {
       browserManager,
@@ -60,6 +62,7 @@ describe("File output integration", () => {
   afterAll(async () => {
     await browserManager.close();
     await fs.rm(outputDir, { recursive: true, force: true });
+    await fs.rm(artifactStoreDir, { recursive: true, force: true });
   });
 
   describe("observe with output_file", () => {


### PR DESCRIPTION
## Summary
- **#76**: Add `if (resolvedId === null) return false` guard in form field matching to prevent phantom form field references
- **#82**: Pass explicit `"main"` frameId for main-frame landmark ID generation so hash input structure is consistent across all frames
- **#70**: Replace `split("=")[1]` with `substring(indexOf("=") + 1)` for `--output-dir`, `--profile`, and `--tools` CLI flag parsing
- **#71**: Use `fs.mkdtemp` for artifact store dir (instead of hardcoded path) and clean it up in `afterAll`
- **#81**: Add `.min()`/`.max()` Zod constraints to `quality` (1-100), viewport `width`/`height` (≥1), and key `delay` (≥0)

Closes #76, closes #82, closes #70, closes #71, closes #81

## Test plan
- [x] All 503 tests pass (39 files — 261 unit + 242 integration)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] Verified artifact store temp dir is cleaned up after test run

// ticktockbent