### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Charlotte will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-09
+
+### Added
+
+- **Iframe content extraction** — Child frames are now discovered and their content (interactive elements, content summaries, full text) is merged into the parent page representation. Configurable depth limit (default 3). Iframe interactive elements are included in the `interactive` array and `interactive_summary`. Closes #23.
+- **Structural tree view** — `charlotte:observe` now accepts a `view` parameter with `"tree"` and `"tree-labeled"` modes that render the page as a hierarchical tree with indentation, replacing the flat JSON representation. Tree-labeled mode annotates interactive elements with their IDs for direct use.
+- **File output for large responses** — `charlotte:observe` and `charlotte:screenshot` accept an `output_file` parameter to write results to disk instead of returning inline, reducing token consumption for large pages. Relative paths resolve against `output_dir` (configurable via `charlotte:configure` or `--output-dir` CLI flag). Closes GAP-13, #16.
+- **Screenshot artifact management** — `charlotte:screenshots` (list), `charlotte:screenshot_get` (retrieve), `charlotte:screenshot_delete` (remove) tools for managing persistent screenshot files. `charlotte:screenshot` gains a `save` parameter for persistence.
+- **Code quality tooling** — ESLint, Prettier, and coverage configuration added to the project.
+
+### Fixed
+
+- **`wait_for` JS evaluation** — Replaced `new Function("return " + expr)` with CDP `Runtime.evaluate`, fixing multi-statement JS conditions that silently returned `undefined` due to ASI. Now consistent with `charlotte:evaluate`. Fixes #73.
+- **Browser reconnection race** — `getBrowser()` now calls `ensureConnected()` to auto-recover instead of throwing immediately. `ensureConnected()` verifies browser health after awaiting concurrent launches. Fixes #83.
+- **Renderer pipeline resilience** — Malformed AX properties no longer crash accessibility extraction (#86). Content extraction skips failed nodes instead of aborting (#79). Recursive frame traversal catches errors per-frame (#74). Batch layout extraction uses `Promise.allSettled()` for partial failure tolerance (#77).
+- **Event listener cleanup** — `closeTab()` now explicitly removes all page event listeners before `page.close()` to prevent memory leaks across tab cycles. Fixes #89.
+- **Dialog handler error handling** — Dialog event handler wrapped in try/catch to prevent unhandled promise rejections when dialog is already dismissed. Fixes #75.
+- **Dev mode shutdown resilience** — `DevModeState.stopAll()` catches errors per substep so a file watcher or static server failure doesn't prevent browser cleanup. Fixes #80.
+- **Form field matching null guard** — `resolveId()` null return no longer produces false-positive form field matches. Fixes #76.
+- **Landmark ID collision** — Main-frame landmarks now pass explicit `"main"` frameId for consistent hash input, preventing rare cross-frame ID collisions. Fixes #82.
+- **CLI argument parsing** — `--output-dir=`, `--profile=`, and `--tools=` flags now use `substring(indexOf("=") + 1)` instead of `split("=")[1]`, preserving paths containing `=`. Fixes #70.
+- **Zod bounds validation** — Added `.min()`/`.max()` constraints to `quality` (1-100), viewport `width`/`height` (>=1), and key `delay` (>=0). Fixes #81.
+- **Test cleanup** — File output integration test no longer leaks artifact store temp directory. Fixes #71.
+- **File output security** — Path traversal prevention, mkdir-before-validation fix, and CLI `output-dir` initialization hardened. Fixes security issues from #16 review.
+
+### Changed
+
+- README rewritten with problem-first opening, expanded MCP client setup configs (Cursor, Windsurf, VS Code, Cline, Amp), and updated tool counts.
+- npm package description and keywords updated for discoverability.
+- Site meta descriptions updated to lead with token-efficiency comparison.
+
 ## [0.4.2] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charlotte decomposes each page into a typed, structured representation — landm
 
 ### Benchmarks
 
-Charlotte v0.4.2 vs Playwright MCP, measured by characters returned per tool call on real websites:
+Charlotte v0.5.0 vs Playwright MCP, measured by characters returned per tool call on real websites:
 
 **Navigation** (first contact with a page):
 
@@ -39,7 +39,7 @@ Charlotte's `navigate` returns minimal detail by default — landmarks, headings
 | browse (default) | 23 | ~3,900 | **~47%** |
 | core | 7 | 1,677 | **~77%** |
 
-Tool definitions are sent on every API round-trip. With the default `browse` profile, Charlotte carries ~47% less definition overhead than loading all 42 tools. Over a 20-call browsing session, that's **~38% fewer total tokens**. See the [profile benchmark report](docs/charlotte-profile-benchmark-report.md) for full results.
+Tool definitions are sent on every API round-trip. With the default `browse` profile, Charlotte carries ~47% less definition overhead than loading all tools. Over a 20-call browsing session, that's **~38% fewer total tokens**. See the [profile benchmark report](docs/charlotte-profile-benchmark-report.md) for full results.
 
 **The workflow difference:** Playwright agents receive 61K+ characters every time they look at Hacker News, whether they're reading headlines or looking for a login button. Charlotte agents get 336 characters on arrival, call `find({ type: "link", text: "login" })` to get exactly what they need, and never pay for the rest.
 
@@ -69,7 +69,7 @@ Agents receive landmarks, headings, interactive elements with typed metadata, bo
 
 **Navigation** — `navigate`, `back`, `forward`, `reload`
 
-**Observation** — `observe` (3 detail levels), `find` (spatial + semantic search, CSS selector mode), `screenshot`, `diff` (structural comparison against snapshots)
+**Observation** — `observe` (3 detail levels, structural tree view), `find` (spatial + semantic search, CSS selector mode), `screenshot` (with persistent artifact management), `screenshots`, `screenshot_get`, `screenshot_delete`, `diff` (structural comparison against snapshots)
 
 **Interaction** — `click`, `click_at` (coordinate-based), `type`, `select`, `toggle`, `submit`, `scroll`, `hover`, `drag`, `key` (single/sequence with element targeting), `wait_for` (async condition polling), `upload` (file input), `dialog` (accept/dismiss JS dialogs)
 
@@ -83,7 +83,7 @@ Agents receive landmarks, headings, interactive elements with typed metadata, bo
 
 ## Tool Profiles
 
-Charlotte ships 42 tools, but most workflows only need a subset. Startup profiles control which tools load into the agent's context, reducing definition overhead by up to 77%.
+Charlotte ships 42 tools (41 registered + the `charlotte:tools` meta-tool), but most workflows only need a subset. Startup profiles control which tools load into the agent's context, reducing definition overhead by up to 77%.
 
 ```bash
 charlotte --profile browse    # 23 tools (default) — navigate, observe, interact, tabs
@@ -433,7 +433,7 @@ All tools go through `renderActivePage()` which handles snapshots, reload events
 
 ## Sandbox
 
-Charlotte includes a test website in `tests/sandbox/` that exercises all 42 tools without touching the public internet. Serve it locally with:
+Charlotte includes a test website in `tests/sandbox/` that exercises all tools without touching the public internet. Serve it locally with:
 
 ```
 dev_serve({ path: "tests/sandbox" })
@@ -444,8 +444,6 @@ Four pages cover navigation, forms, interactive elements, delayed content, scrol
 ## Known Issues
 
 **Tool naming convention** — Charlotte uses `:` as a namespace separator in tool names (e.g., `charlotte:navigate`, `charlotte:observe`). MCP SDK v1.26.0+ logs validation warnings for this character, as the emerging [SEP standard](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986) restricts tool names to `[A-Za-z0-9_.-]`. This does not affect functionality — all tools work correctly — but produces stderr warnings on server startup. Will be addressed in a future release to comply with the SEP standard.
-
-**Iframe content not captured** — Charlotte reads the main frame's accessibility tree only. Content inside iframes (same-origin or cross-origin) is not included in the page representation. See the Roadmap for planned iframe support.
 
 **Shadow DOM** — Open shadow DOM works transparently. Chromium's accessibility tree pierces open shadow boundaries, so web components (e.g., GitHub's `<relative-time>`, `<tool-tip>`) render their content into Charlotte's representation without special handling. Closed shadow roots are opaque to the accessibility tree and will not be captured.
 
@@ -465,19 +463,13 @@ Four pages cover navigation, forms, interactive elements, delayed content, scrol
 
 **Configuration File** — Support a `--config` CLI argument to load settings from a JSON file, simplifying repeatable setups and CI/CD integration.
 
-**File Output** — Add an optional `filename` parameter to `screenshot`, `observe`, and future monitoring tools so large responses can be written to disk instead of returned inline, reducing token consumption.
-
 **Full Device Emulation** — Extend `charlotte:viewport` to accept named devices (e.g., "iPhone 15") and configure user agent, touch support, and device pixel ratio via CDP, not just viewport dimensions.
 
 ### Feature Roadmap
 
-**Screenshot Artifacts** — Save screenshots as persistent file artifacts rather than only returning inline data, enabling agents to reference and manage captured images across sessions.
-
 **Video Recording** — Record interactions as video, capturing the full sequence of agent-driven navigation and manipulation for debugging, documentation, and review.
 
 **ARM64 Docker Images** — Add `linux/arm64` platform support to the Docker publish workflow for native performance on Apple Silicon Macs and ARM servers.
-
-**Iframe Content Extraction** — Traverse child frames via CDP to include iframe content in the page representation. Currently, Charlotte only reads the main frame's accessibility tree; same-origin and cross-origin iframe content is invisible.
 
 See [docs/playwright-mcp-gap-analysis.md](docs/playwright-mcp-gap-analysis.md) for the full gap analysis against Playwright MCP, including lower-priority items (vision tools, testing/verification, tracing, transport, security) and areas where Charlotte has advantages.
 

--- a/docs/CHARLOTTE_SPEC.md
+++ b/docs/CHARLOTTE_SPEC.md
@@ -1,6 +1,6 @@
 # Charlotte Technical Specification
 
-**Version:** 0.4.2
+**Version:** 0.5.0
 
 Charlotte is an MCP server that renders web pages into structured, agent-readable `PageRepresentation` objects using headless Chromium and Puppeteer. It communicates over stdio using the Model Context Protocol.
 
@@ -96,6 +96,7 @@ interface PageRepresentation {
     network: Array<{ url: string; status: number; statusText: string }>;
   };
   interactive_summary?: InteractiveSummary;  // Present at minimal detail level
+  iframes?: IframeInfo[];                     // Present when child frames are discovered
   reload_event?: ReloadEvent;                // Present when dev_serve detects file changes
   pending_dialog?: PendingDialog;            // Present when a JS dialog is blocking
   delta?: SnapshotDiff;                      // Present after interaction tools
@@ -223,6 +224,19 @@ interface InteractiveSummary {
 
 Present at minimal detail level. `by_landmark` keys match landmark format: `"role (label)"`, `"role"` for unlabeled, or `"(page root)"` for elements outside any landmark.
 
+### IframeInfo
+
+```typescript
+interface IframeInfo {
+  url: string;
+  bounds: Bounds | null;
+}
+```
+
+Present when child frames are discovered during rendering. Interactive elements from iframes are merged into the parent `interactive` array and `interactive_summary`. Content summaries and full text are appended with iframe URL prefixes.
+
+Iframe discovery depth is configurable (default: 3 levels).
+
 ---
 
 ## Element Identity
@@ -283,6 +297,7 @@ elementType | role | name | nearestLandmarkRole | nearestLandmarkLabel | nearest
 | `form` | `frm` |
 | `region` | `rgn` |
 | `heading` | `hdg` |
+| `dom_element` | `dom` |
 | *(fallback)* | `el` |
 
 ### Collision Handling
@@ -362,8 +377,10 @@ Get current page state without performing any action.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `detail` | `"minimal" \| "summary" \| "full"` | No | `"summary"` | Verbosity level |
+| `view` | `"default" \| "tree" \| "tree-labeled"` | No | `"default"` | Output format. `"tree"` renders a hierarchical text tree. `"tree-labeled"` adds interactive element IDs. |
 | `selector` | `string` | No | — | CSS selector to scope observation |
 | `include_styles` | `boolean` | No | `false` | Include computed styles |
+| `output_file` | `string` | No | — | Write to file instead of returning inline. Relative paths resolve against `output_dir`. |
 
 #### `charlotte:find`
 
@@ -393,8 +410,10 @@ Capture a visual screenshot.
 | `selector` | `string` | No | — | CSS selector for specific element |
 | `format` | `"png" \| "jpeg" \| "webp"` | No | `"png"` | Image format |
 | `quality` | `number` | No | — | 1-100 for jpeg/webp |
+| `save` | `boolean` | No | `false` | Save as a persistent file artifact |
+| `output_file` | `string` | No | — | Write to file instead of returning base64 inline. Mutually exclusive with `save`. |
 
-**Returns:** Base64-encoded image. When `screenshot_dir` is configured via `charlotte:configure`, also persists the screenshot as a file artifact.
+**Returns:** Base64-encoded image. When `save` is true, also persists the screenshot as a file artifact with metadata.
 
 #### `charlotte:screenshots`
 
@@ -718,6 +737,7 @@ Headers persist for all subsequent requests on the active page.
 | `snapshot_depth` | `number` | No | `50` | Ring buffer size (5-500) |
 | `auto_snapshot` | `"every_action" \| "observe_only" \| "manual"` | No | `"every_action"` | Auto-snapshot mode |
 | `screenshot_dir` | `string` | No | *(OS temp dir)* | Directory for persistent screenshot artifacts |
+| `output_dir` | `string` | No | — | Base directory for `output_file` paths on observe/screenshot |
 | `dialog_auto_dismiss` | `"none" \| "accept_alerts" \| "accept_all" \| "dismiss_all"` | No | `"none"` | Auto-dismiss behavior for JS dialogs |
 
 See [Configuration](#configuration) for details.
@@ -861,6 +881,7 @@ interface CharlotteConfig {
   autoSnapshot: AutoSnapshotMode;           // Default: "every_action"
   dialogAutoDismiss: DialogAutoDismiss;     // Default: "none"
   screenshotDir?: string;                   // Default: OS temp dir
+  outputDir?: string;                        // Base dir for output_file paths
 }
 
 type AutoSnapshotMode = "every_action" | "observe_only" | "manual";

--- a/docs/playwright-mcp-gap-analysis.md
+++ b/docs/playwright-mcp-gap-analysis.md
@@ -126,12 +126,12 @@ where Charlotte has capabilities Playwright MCP does not**, for completeness.
 | **Suggested Change** | Add `slowly` or `character_delay` parameter to `charlotte:type` |
 | **Implementation Notes** | Puppeteer's `page.keyboard.type(text, {delay})` supports this natively. |
 
-### GAP-06: Click with Modifier Keys
+### GAP-06: Click with Modifier Keys — *remediated in v0.4.0*
 
 | Attribute | Detail |
 |-----------|--------|
 | **Playwright Tool** | `browser_click` with `modifiers` parameter (`["Control", "Shift", "Alt", "Meta"]`) |
-| **Charlotte Status** | Partial — `charlotte:click` has `click_type` (left/right/double) but no modifier key support |
+| **Charlotte Status** | Implemented — `charlotte:click` accepts `modifiers` parameter (`ctrl`, `shift`, `alt`, `meta`, or combinations). Works with all click types. |
 | **Impact** | Medium — blocks Ctrl+Click (open in new tab), Shift+Click (range select), etc. |
 | **Parameters (Playwright)** | `modifiers` (array of modifier key names) |
 | **Suggested Change** | Add `modifiers` parameter to `charlotte:click` |
@@ -143,12 +143,12 @@ where Charlotte has capabilities Playwright MCP does not**, for completeness.
 
 Charlotte operates exclusively in semantic/accessibility mode. Playwright MCP's entire `vision` capability group (6 tools) has no Charlotte equivalent.
 
-### GAP-07: Coordinate-Based Click (`browser_mouse_click_xy`)
+### GAP-07: Coordinate-Based Click (`browser_mouse_click_xy`) — *remediated in v0.4.1*
 
 | Attribute | Detail |
 |-----------|--------|
 | **Impact** | Medium — needed for canvas elements, custom widgets, and elements not in the accessibility tree |
-| **Suggested Tool Name** | `charlotte:click_xy` |
+| **Charlotte Status** | Implemented as `charlotte:click_at` with `x`, `y`, `click_type`, and `modifiers` parameters. |
 
 ### GAP-08: Coordinate-Based Mouse Move (`browser_mouse_move_xy`)
 
@@ -198,15 +198,13 @@ Charlotte operates exclusively in semantic/accessibility mode. Playwright MCP's 
 | **Suggested Tool Name** | `charlotte:pdf` |
 | **Implementation Notes** | Puppeteer supports `page.pdf()` natively. Chromium-only limitation applies to both. |
 
-### GAP-13: Save Outputs to Files
+### GAP-13: Save Outputs to Files — *remediated in v0.5.0*
 
 | Attribute | Detail |
 |-----------|--------|
 | **Playwright Feature** | `filename` parameter on `browser_snapshot`, `browser_take_screenshot`, `browser_console_messages`, `browser_network_requests` |
-| **Charlotte Status** | All data returned inline in tool responses only |
+| **Charlotte Status** | Implemented — `charlotte:observe` and `charlotte:screenshot` accept `output_file` parameter to write results to disk. Relative paths resolve against `output_dir` (configurable via `charlotte:configure` or `--output-dir` CLI flag). Screenshot artifact management via `screenshots`, `screenshot_get`, `screenshot_delete` tools. |
 | **Impact** | Medium — file output reduces token consumption for large responses, enables post-session analysis |
-| **Suggested Change** | Add optional `filename` / `save_to` parameter on `screenshot`, `observe`, and future monitoring tools |
-| **Implementation Notes** | Charlotte's roadmap already mentions "Screenshot Artifacts". |
 
 ---
 
@@ -588,14 +586,14 @@ Features Charlotte provides that Playwright MCP **does not** have as dedicated t
 | GAP-03 | Interaction | Dialog handling | `browser_handle_dialog` | Remediated in v0.3.0 | High |
 | GAP-04 | Interaction | Batch form fill | `browser_fill_form` | Missing | Medium |
 | GAP-05 | Interaction | Slow typing | `slowly` param | Missing | Medium |
-| GAP-06 | Interaction | Click modifiers | `modifiers` param | Missing | Medium |
-| GAP-07 | Vision | Coordinate click | `browser_mouse_click_xy` | Missing | Medium |
+| GAP-06 | Interaction | Click modifiers | `modifiers` param | Remediated in v0.4.0 | Medium |
+| GAP-07 | Vision | Coordinate click | `browser_mouse_click_xy` | Remediated in v0.4.1 | Medium |
 | GAP-08 | Vision | Coordinate move | `browser_mouse_move_xy` | Missing | Medium |
 | GAP-09 | Vision | Coordinate drag | `browser_mouse_drag_xy` | Missing | Medium |
 | GAP-10 | Vision | Mouse down/up | `browser_mouse_down/up` | Missing | Low |
 | GAP-11 | Vision | Mouse wheel | `browser_mouse_wheel` | Missing | Low |
 | GAP-12 | Export | PDF generation | `browser_pdf_save` | Missing | Low-Med |
-| GAP-13 | Export | Save to files | `filename` param | Missing | Medium |
+| GAP-13 | Export | Save to files | `filename` param | Remediated in v0.5.0 | Medium |
 | GAP-14 | Testing | Verify element visible | `browser_verify_element_visible` | Missing | Medium |
 | GAP-15 | Testing | Verify text visible | `browser_verify_text_visible` | Missing | Medium |
 | GAP-16 | Testing | Verify list | `browser_verify_list_visible` | Missing | Low |
@@ -624,7 +622,7 @@ Features Charlotte provides that Playwright MCP **does not** have as dedicated t
 | GAP-39 | Security | Origin allow/block | `--allowed/blocked-origins` | Missing | Medium |
 | GAP-40 | Security | Service worker blocking | `--block-service-workers` | Missing | Low |
 | GAP-41 | Security | HTTPS error ignoring | `--ignore-https-errors` | Missing | Low-Med |
-| GAP-42 | Security | Capability gating | `--caps` flag | Missing | Medium |
+| GAP-42 | Security | Capability gating | `--caps` flag | Remediated in v0.4.0 (profiles) | Medium |
 | GAP-43 | Security | Secrets management | `--secrets` flag | Missing | Low |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Token-efficient browser MCP server — structured web pages for AI agents, not raw accessibility dumps",
   "type": "module",
   "main": "dist/index.js",

--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -19,6 +19,22 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "0.5.0",
+    date: "2026-03-09",
+    entries: [
+      { type: "added", text: "Iframe content extraction — Child frame content (interactive elements, text, summaries) merged into parent page representation. Configurable depth." },
+      { type: "added", text: "Structural tree view — charlotte:observe accepts view: \"tree\" and \"tree-labeled\" for hierarchical text output with optional element IDs." },
+      { type: "added", text: "File output — charlotte:observe and charlotte:screenshot accept output_file to write results to disk, reducing token consumption. Closes GAP-13." },
+      { type: "added", text: "Screenshot artifact management — screenshots, screenshot_get, screenshot_delete tools for persistent screenshot files." },
+      { type: "fixed", text: "wait_for JS evaluation now uses CDP Runtime.evaluate, fixing multi-statement conditions that silently returned undefined." },
+      { type: "fixed", text: "Browser reconnection race — getBrowser() auto-recovers via ensureConnected() instead of throwing immediately." },
+      { type: "fixed", text: "Renderer pipeline resilience — malformed AX properties, failed content nodes, bad iframes, and transient CDP errors no longer crash renders." },
+      { type: "fixed", text: "Event listener cleanup on tab close, dialog handler error handling, and dev mode shutdown resilience." },
+      { type: "fixed", text: "Form field matching null guard, landmark ID cross-frame collision, CLI arg parsing with = in paths, and Zod bounds validation." },
+      { type: "changed", text: "README rewritten with problem-first opening. MCP client configs added for Cursor, Windsurf, VS Code, Cline, and Amp." },
+    ],
+  },
+  {
     version: "0.4.2",
     date: "2026-03-06",
     entries: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,7 +77,7 @@ export function createServer(deps: ServerDeps, options: ServerOptions = {}): Cre
   const server = new McpServer(
     {
       name: "charlotte",
-      version: "0.4.2",
+      version: "0.5.0",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary
Release preparation for Charlotte v0.5.0.

### New features
- Iframe content extraction — child frames merged into page representation
- Structural tree view (`view: "tree"` / `"tree-labeled"` on observe)
- File output for large responses (`output_file` on observe/screenshot)
- Screenshot artifact management (screenshots, screenshot_get, screenshot_delete)

### Bug fixes (14 issues)
- #70, #71, #73, #74, #75, #76, #77, #79, #80, #81, #82, #83, #86, #89
- File output security hardening from #16 review

### Release prep changes
- Version bumped to 0.5.0 in `package.json` and `src/server.ts`
- CHANGELOG.md updated with full v0.5.0 section
- README updated (benchmark version, features, removed implemented roadmap/known issues)
- CHARLOTTE_SPEC.md updated (version, new params, IframeInfo type, dom_element prefix)
- Gap analysis: GAP-06, GAP-07, GAP-13, GAP-42 marked remediated
- Website changelog: v0.5.0 entry added

### Post-merge
- Tag `v0.5.0` already pushed to `c111b1f`
- Run `npm publish` after merge
- Deploy website

## Test plan
- [x] 503/503 tests pass
- [x] TypeScript type check clean
- [x] Site builds clean

// ticktockbent