### PR TITLE
Rename AXIOM to ASM across Charlotte site

### DIFF
--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -139,7 +139,7 @@ const typeBadgeClass: Record<ChangeEntry["type"], string> = {
 
 export default function ChangelogPage() {
   return (
-    <div className="min-h-screen bg-background" data-axiom-page-type="documentation" data-axiom-page-purpose="View the complete release history for Charlotte, including new features, changes, fixes, and removals for each version.">
+    <div className="min-h-screen bg-background" data-asm-page-type="documentation" data-asm-page-purpose="View the complete release history for Charlotte, including new features, changes, fixes, and removals for each version.">
       {/* Nav */}
       <nav aria-label="Site navigation" className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-sm border-b border-surface-border">
         <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 h-14 flex items-center justify-between">

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <head>
-        <link rel="axiom-manifest" type="application/json" href="/axiom.json" />
+        <link rel="asm-manifest" type="application/json" href="/agents.json" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -9,7 +9,7 @@ import Footer from "../components/Footer";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-background" data-axiom-page-type="homepage" data-axiom-page-purpose="Learn about Charlotte, an MCP server for token-efficient web browsing by AI agents. View benchmarks, tools, examples, and installation instructions.">
+    <div className="min-h-screen bg-background" data-asm-page-type="homepage" data-asm-page-purpose="Learn about Charlotte, an MCP server for token-efficient web browsing by AI agents. View benchmarks, tools, examples, and installation instructions.">
       {/* Nav */}
       <nav aria-label="Primary navigation" className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-sm border-b border-surface-border">
         <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12 h-14 flex items-center justify-between">

--- a/site/app/vs-playwright/page.tsx
+++ b/site/app/vs-playwright/page.tsx
@@ -346,7 +346,7 @@ export default function VsPlaywrightPage() {
   };
 
   return (
-    <div className="min-h-screen bg-background" data-axiom-page-type="article" data-axiom-page-purpose="Compare Charlotte and Playwright MCP with real benchmark data across response sizes, token costs, and feature matrices. Determine which browser MCP server fits your use case.">
+    <div className="min-h-screen bg-background" data-asm-page-type="article" data-asm-page-purpose="Compare Charlotte and Playwright MCP with real benchmark data across response sizes, token costs, and feature matrices. Determine which browser MCP server fits your use case.">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/site/components/Benchmarks.tsx
+++ b/site/components/Benchmarks.tsx
@@ -100,7 +100,7 @@ export default function Benchmarks() {
   const activeTabInfo = tabs.find((t) => t.key === activeTab)!;
 
   return (
-    <section id="benchmarks" className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border" data-axiom-role="primary-content" data-axiom-summary="Performance benchmarks comparing Charlotte vs Playwright MCP response sizes and token costs across real websites." data-axiom-priority="high">
+    <section id="benchmarks" className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border" data-asm-role="primary-content" data-asm-summary="Performance benchmarks comparing Charlotte vs Playwright MCP response sizes and token costs across real websites." data-asm-priority="high">
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold tracking-tight mb-4">
           Benchmarks

--- a/site/components/BuiltWithCharlotte.tsx
+++ b/site/components/BuiltWithCharlotte.tsx
@@ -1,6 +1,6 @@
 export default function BuiltWithCharlotte() {
   return (
-    <section className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border" data-axiom-role="supplementary" data-axiom-summary="Story of how this website was built entirely by an AI agent using Charlotte for visual feedback." data-axiom-priority="low">
+    <section className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border" data-asm-role="supplementary" data-asm-summary="Story of how this website was built entirely by an AI agent using Charlotte for visual feedback." data-asm-priority="low">
       <div className="max-w-2xl mx-auto">
         <h2 className="text-2xl font-bold tracking-tight mb-6">
           This page was built by an agent.

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -49,7 +49,7 @@ function ArchitectureDiagram() {
 
 export default function Hero() {
   return (
-    <section className="relative pt-24 pb-20 px-6 sm:px-8 lg:px-12" data-axiom-role="primary-content" data-axiom-summary="Charlotte overview: an MCP server that renders web pages into structured, agent-readable representations. 136x smaller responses than Playwright MCP, 7 tools to start / 42 total, 3 detail levels." data-axiom-priority="critical">
+    <section className="relative pt-24 pb-20 px-6 sm:px-8 lg:px-12" data-asm-role="primary-content" data-asm-summary="Charlotte overview: an MCP server that renders web pages into structured, agent-readable representations. 136x smaller responses than Playwright MCP, 7 tools to start / 42 total, 3 detail levels." data-asm-priority="critical">
       <div className="max-w-5xl mx-auto">
         <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-12">
           {/* Left: Text content */}
@@ -84,8 +84,8 @@ export default function Hero() {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-foreground text-background font-medium text-sm hover:bg-foreground/90 transition-colors"
-                data-axiom-action="navigate"
-                data-axiom-intent="view-source-code"
+                data-asm-action="navigate"
+                data-asm-intent="view-source-code"
               >
                 <svg
                   width="18"
@@ -103,8 +103,8 @@ export default function Hero() {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-surface-border font-medium text-sm hover:bg-surface-hover transition-colors"
-                data-axiom-action="navigate"
-                data-axiom-intent="view-package-registry"
+                data-asm-action="navigate"
+                data-asm-intent="view-package-registry"
               >
                 <svg
                   width="18"

--- a/site/components/OutputDemo.tsx
+++ b/site/components/OutputDemo.tsx
@@ -80,7 +80,7 @@ export default function OutputDemo() {
   const [activeDetail, setActiveDetail] = useState<DetailTab>("minimal");
 
   return (
-    <section id="output" className="py-20 px-6 sm:px-8 lg:px-12" data-axiom-role="primary-content" data-axiom-summary="Example Charlotte responses at minimal and summary detail levels. Shows the structured JSON format agents receive." data-axiom-priority="high">
+    <section id="output" className="py-20 px-6 sm:px-8 lg:px-12" data-asm-role="primary-content" data-asm-summary="Example Charlotte responses at minimal and summary detail levels. Shows the structured JSON format agents receive." data-asm-priority="high">
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold tracking-tight mb-4">
           What Charlotte Returns

--- a/site/components/QuickStart.tsx
+++ b/site/components/QuickStart.tsx
@@ -25,9 +25,9 @@ export default function QuickStart() {
     <section
       id="quickstart"
       className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border"
-      data-axiom-role="interactive"
-      data-axiom-summary="Installation and setup instructions for Charlotte. Add to Claude Code, Claude Desktop, or any MCP-compatible client."
-      data-axiom-priority="critical"
+      data-asm-role="interactive"
+      data-asm-summary="Installation and setup instructions for Charlotte. Add to Claude Code, Claude Desktop, or any MCP-compatible client."
+      data-asm-priority="critical"
     >
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold tracking-tight mb-4">Quick Start</h2>

--- a/site/components/ToolGrid.tsx
+++ b/site/components/ToolGrid.tsx
@@ -148,9 +148,9 @@ export default function ToolGrid() {
     <section
       id="tools"
       className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border"
-      data-axiom-role="primary-content"
-      data-axiom-summary="All 40 Charlotte tools organized into 8 categories: Navigation, Observation, Interaction, Session, Dev Mode, Utility, Monitoring, and Meta."
-      data-axiom-priority="high"
+      data-asm-role="primary-content"
+      data-asm-summary="All 40 Charlotte tools organized into 8 categories: Navigation, Observation, Interaction, Session, Dev Mode, Utility, Monitoring, and Meta."
+      data-asm-priority="high"
     >
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold tracking-tight mb-4">

--- a/site/components/UsageExamples.tsx
+++ b/site/components/UsageExamples.tsx
@@ -61,9 +61,9 @@ export default function UsageExamples() {
     <section
       id="examples"
       className="py-20 px-6 sm:px-8 lg:px-12 border-t border-surface-border"
-      data-axiom-role="primary-content"
-      data-axiom-summary="Code examples showing Charlotte tool usage for browsing websites, filling forms, and local development with hot reload."
-      data-axiom-priority="medium"
+      data-asm-role="primary-content"
+      data-asm-summary="Code examples showing Charlotte tool usage for browsing websites, filling forms, and local development with hot reload."
+      data-asm-priority="medium"
     >
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold tracking-tight mb-4">

--- a/site/public/agents.json
+++ b/site/public/agents.json
@@ -1,5 +1,5 @@
 {
-  "axiom_version": "1.0",
+  "asm_version": "1.0",
 
   "site": {
     "name": "Charlotte",

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -2,4 +2,4 @@ User-Agent: *
 Allow: /
 
 Sitemap: https://charlotte-rose.vercel.app/sitemap.xml
-Axiom: /axiom.json
+ASM: /agents.json


### PR DESCRIPTION
## Summary
- Renames `axiom.json` → `agents.json` with `asm_version` field, per the [ASM spec](https://github.com/Clocktower-and-Associates/ASM)
- Updates `robots.txt` directive and `layout.tsx` manifest link
- Replaces all `data-axiom-*` attributes with `data-asm-*` across 10 site components

## Test plan
- [ ] Verify site builds (`npm run build` in `site/`)
- [ ] Confirm `/agents.json` is served correctly on deploy
- [ ] Spot-check `data-asm-*` attributes in rendered HTML

// ticktockbent