### PR TITLE
Add issue templates and community links for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible bug in Charlotte
+title: "[bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the bug in one or two sentences.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What should have happened?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Charlotte version:
+- Node.js version:
+- OS:
+- MCP client used:
+
+## Additional context
+
+Include logs, screenshots, traces, or fixture pages if relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/TickTockBent/charlotte/blob/main/CONTRIBUTING.md
+    about: Read the contribution workflow, test expectations, and project structure before opening a larger change.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability for Charlotte
+title: "[feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem to solve
+
+What workflow, limitation, or pain point are you trying to address?
+
+## Proposed solution
+
+Describe the change you would like to see.
+
+## Alternatives considered
+
+What other approaches did you evaluate?
+
+## Additional context
+
+Examples, screenshots, pseudo-APIs, or references are welcome.

--- a/.github/ISSUE_TEMPLATE/tool_request.md
+++ b/.github/ISSUE_TEMPLATE/tool_request.md
@@ -1,0 +1,34 @@
+---
+name: Tool request
+about: Propose a new Charlotte tool or tool-group capability
+title: "[tool] "
+labels: enhancement
+assignees: ""
+---
+
+## Tool idea
+
+What should the new tool do?
+
+## Intended use case
+
+Describe the workflow this tool would unlock or simplify.
+
+## Suggested parameters
+
+List the input fields or options you expect the tool to support.
+
+## Proposed profile placement
+
+Where should this tool live by default?
+
+- core
+- browse
+- interact
+- develop
+- audit
+- full only
+
+## Rationale
+
+Why is this better as a dedicated tool instead of a combination of existing tools?

--- a/README.md
+++ b/README.md
@@ -481,6 +481,14 @@ See [docs/CHARLOTTE_SPEC.md](docs/CHARLOTTE_SPEC.md) for the complete specificat
 
 [MIT](LICENSE)
 
+## Community
+
+- Open a [bug report](https://github.com/TickTockBent/charlotte/issues/new?template=bug_report.md) for reproducible defects, regressions, or MCP-client-specific problems.
+- Open a [feature request](https://github.com/TickTockBent/charlotte/issues/new?template=feature_request.md) for workflow improvements or new capabilities.
+- Open a [tool request](https://github.com/TickTockBent/charlotte/issues/new?template=tool_request.md) if you want to propose a new tool, parameter surface, or profile placement.
+- Browse [open issues](https://github.com/TickTockBent/charlotte/issues) to find current work and discussion.
+- Check the planned [good first issue filter](https://github.com/TickTockBent/charlotte/issues?q=is%3Aopen+label%3A%22good+first+issue%22) as maintainers tag starter-friendly tasks.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary
- add issue templates for bug reports, feature requests, and tool requests
- add issue template config with a contribution-guide contact link
- add a short Community section to the README with contributor entry points

## Why
This addresses the PR-friendly part of #62 by giving new contributors a clearer path to report bugs, propose ideas, and find where to start.

Closes #62