### PR TITLE
Capture popups and target="_blank" tabs in PageManager

### DIFF
--- a/src/browser/page-manager.ts
+++ b/src/browser/page-manager.ts
@@ -50,24 +50,20 @@ export class PageManager {
   private pages = new Map<string, ManagedPage>();
   private activeTabId: string | null = null;
   private config: CharlotteConfig;
+  /** Tab IDs of pages opened by popups since the last drain. */
+  private newTabQueue: string[] = [];
 
   constructor(config?: CharlotteConfig) {
     // Accept optional config; callers without config get a permissive default
     this.config = config ?? createDefaultConfig();
   }
 
-  async openTab(browserManager: BrowserManager, url?: string): Promise<string> {
-    const page = await browserManager.newPage();
-    const tabId = generateTabId();
-
-    const managedPage: ManagedPage = {
-      id: tabId,
-      page,
-      consoleMessages: [],
-      networkRequests: [],
-      pendingDialog: null,
-      pendingDialogInfo: null,
-    };
+  /**
+   * Wire up event listeners on a managed page: console, network, dialog,
+   * framenavigated, popup, and close. Shared by openTab() and the popup handler.
+   */
+  private wirePageListeners(managedPage: ManagedPage): void {
+    const { page, id: tabId } = managedPage;
 
     // Collect all console messages
     page.on("console", (msg) => {
@@ -139,6 +135,73 @@ export class PageManager {
       }
     });
 
+    // Capture popups (target="_blank" links, window.open()) as managed tabs
+    page.on("popup", (popupPage) => {
+      if (popupPage) {
+        this.registerPopupPage(popupPage);
+      }
+    });
+
+    // Auto-clean when a page closes itself (window.close(), site-initiated)
+    page.on("close", () => {
+      if (this.pages.has(tabId)) {
+        this.pages.delete(tabId);
+        logger.info(`Tab ${tabId} closed by page`);
+        if (this.activeTabId === tabId) {
+          const remaining = this.pages.keys().next();
+          this.activeTabId = remaining.done ? null : remaining.value;
+        }
+      }
+    });
+  }
+
+  /**
+   * Register a popup page as a managed tab. Called by the popup event handler.
+   */
+  private registerPopupPage(popupPage: Page): void {
+    const popupTabId = generateTabId();
+    const managedPopup: ManagedPage = {
+      id: popupTabId,
+      page: popupPage,
+      consoleMessages: [],
+      networkRequests: [],
+      pendingDialog: null,
+      pendingDialogInfo: null,
+    };
+
+    this.wirePageListeners(managedPopup);
+    this.pages.set(popupTabId, managedPopup);
+    this.newTabQueue.push(popupTabId);
+
+    logger.info(`Captured popup as ${popupTabId}`, { url: popupPage.url() });
+  }
+
+  /**
+   * Drain the new-tab queue. Returns tab IDs of pages opened by popups since
+   * the last call, then clears the queue (single-consumption semantics).
+   */
+  consumeNewTabs(): string[] {
+    if (this.newTabQueue.length === 0) return [];
+    const tabs = [...this.newTabQueue];
+    this.newTabQueue = [];
+    return tabs;
+  }
+
+  async openTab(browserManager: BrowserManager, url?: string): Promise<string> {
+    const page = await browserManager.newPage();
+    const tabId = generateTabId();
+
+    const managedPage: ManagedPage = {
+      id: tabId,
+      page,
+      consoleMessages: [],
+      networkRequests: [],
+      pendingDialog: null,
+      pendingDialogInfo: null,
+    };
+
+    this.wirePageListeners(managedPage);
+
     this.pages.set(tabId, managedPage);
     this.activeTabId = tabId;
 
@@ -171,6 +234,8 @@ export class PageManager {
     managedPage.page.removeAllListeners("response");
     managedPage.page.removeAllListeners("dialog");
     managedPage.page.removeAllListeners("framenavigated");
+    managedPage.page.removeAllListeners("popup");
+    managedPage.page.removeAllListeners("close");
     await managedPage.page.close();
     this.pages.delete(tabId);
 

--- a/src/tools/tool-helpers.ts
+++ b/src/tools/tool-helpers.ts
@@ -123,6 +123,12 @@ export async function renderActivePage(
     representation.reload_event = pendingReloadEvent;
   }
 
+  // Attach any tabs opened by popups since the last tool call
+  const newTabs = deps.pageManager.consumeNewTabs();
+  if (newTabs.length > 0) {
+    representation.opened_tabs = newTabs;
+  }
+
   return representation;
 }
 
@@ -277,6 +283,11 @@ export function stripEmptyFields(representation: PageRepresentation): Record<str
   // Strip absent pending_dialog
   if (!cleaned.pending_dialog) {
     delete cleaned.pending_dialog;
+  }
+
+  // Strip empty opened_tabs
+  if (!representation.opened_tabs || representation.opened_tabs.length === 0) {
+    delete cleaned.opened_tabs;
   }
 
   return cleaned;

--- a/src/types/page-representation.ts
+++ b/src/types/page-representation.ts
@@ -122,5 +122,7 @@ export interface PageRepresentation {
   iframes?: IframeInfo[];
   reload_event?: ReloadEvent;
   pending_dialog?: PendingDialog;
+  /** Tab IDs of pages opened by popups or target="_blank" links since the last tool call. */
+  opened_tabs?: string[];
   delta?: import("./snapshot.js").SnapshotDiff;
 }

--- a/tests/fixtures/pages/popup.html
+++ b/tests/fixtures/pages/popup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Popup Test</title>
+</head>
+<body>
+  <h1>Popup Test Page</h1>
+  <p>Tests for target="_blank" links and window.open() popup capture.</p>
+
+  <a id="blank-link" href="/simple.html" target="_blank">Open in new tab</a>
+  <button id="window-open" onclick="window.open('/simple.html', '_blank')">Window.open</button>
+  <a id="same-tab-link" href="/simple.html">Same tab link</a>
+</body>
+</html>

--- a/tests/integration/popup.test.ts
+++ b/tests/integration/popup.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import * as http from "node:http";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import { BrowserManager } from "../../src/browser/browser-manager.js";
+import { PageManager } from "../../src/browser/page-manager.js";
+import { CDPSessionManager } from "../../src/browser/cdp-session.js";
+import { RendererPipeline } from "../../src/renderer/renderer-pipeline.js";
+import { ElementIdGenerator } from "../../src/renderer/element-id-generator.js";
+import { SnapshotStore } from "../../src/state/snapshot-store.js";
+import { ArtifactStore } from "../../src/state/artifact-store.js";
+import { createDefaultConfig } from "../../src/types/config.js";
+import type { ToolDependencies } from "../../src/tools/tool-helpers.js";
+import { renderActivePage } from "../../src/tools/tool-helpers.js";
+import { waitForPossibleNavigation } from "../../src/tools/interaction.js";
+
+const FIXTURES_DIR = path.resolve(import.meta.dirname, "../fixtures/pages");
+
+describe("Popup tab capture", () => {
+  let browserManager: BrowserManager;
+  let pageManager: PageManager;
+  let cdpSessionManager: CDPSessionManager;
+  let elementIdGenerator: ElementIdGenerator;
+  let rendererPipeline: RendererPipeline;
+  let deps: ToolDependencies;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    // HTTP server required — target="_blank" doesn't work with file:// URLs
+    server = http.createServer((req, res) => {
+      const requestedPath = req.url === "/" ? "/popup.html" : req.url!;
+      const filePath = path.join(FIXTURES_DIR, requestedPath);
+      try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(content);
+      } catch {
+        res.writeHead(404);
+        res.end("Not found");
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    browserManager = new BrowserManager();
+    await browserManager.launch();
+    pageManager = new PageManager();
+    await pageManager.openTab(browserManager);
+    cdpSessionManager = new CDPSessionManager();
+    elementIdGenerator = new ElementIdGenerator();
+    rendererPipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator);
+    const config = createDefaultConfig();
+    const artifactStore = new ArtifactStore(
+      path.join(os.tmpdir(), "charlotte-popup-test-artifacts"),
+    );
+    await artifactStore.initialize();
+    deps = {
+      browserManager,
+      pageManager,
+      cdpSessionManager,
+      rendererPipeline,
+      elementIdGenerator,
+      snapshotStore: new SnapshotStore(config.snapshotDepth),
+      artifactStore,
+      config,
+    };
+  });
+
+  afterAll(async () => {
+    await browserManager.close();
+    server.close();
+  });
+
+  beforeEach(async () => {
+    // Navigate to the popup fixture and drain any stale new-tab events
+    const page = pageManager.getActivePage();
+    await page.goto(`${baseUrl}/popup.html`, { waitUntil: "load" });
+    pageManager.consumeNewTabs();
+  });
+
+  it("captures target=_blank link clicks as new tabs", async () => {
+    const page = pageManager.getActivePage();
+
+    // Use evaluate to click — Puppeteer's page.click on target="_blank" links
+    // waits for a navigation event that never fires on the current page
+    await page.evaluate(() => {
+      document.getElementById("blank-link")!.click();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const newTabs = pageManager.consumeNewTabs();
+    expect(newTabs.length).toBe(1);
+
+    const tabs = await pageManager.listTabs();
+    const popupTab = tabs.find((t) => t.id === newTabs[0]);
+    expect(popupTab).toBeDefined();
+    expect(popupTab!.url).toContain("/simple.html");
+  });
+
+  it("captures window.open() popups as new tabs", async () => {
+    const page = pageManager.getActivePage();
+
+    // Use evaluate to trigger window.open — page.click("#window-open") hangs
+    // because Puppeteer waits for navigation that never happens on the current page
+    await page.evaluate(() => {
+      document.getElementById("window-open")!.click();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const newTabs = pageManager.consumeNewTabs();
+    expect(newTabs.length).toBe(1);
+
+    const tabs = await pageManager.listTabs();
+    const popupTab = tabs.find((t) => t.id === newTabs[0]);
+    expect(popupTab).toBeDefined();
+    expect(popupTab!.url).toContain("/simple.html");
+  });
+
+  it("surfaces opened_tabs in renderActivePage response", async () => {
+    const page = pageManager.getActivePage();
+
+    // Use evaluate to click — page.click on target="_blank" links hangs
+    await page.evaluate(() => {
+      document.getElementById("blank-link")!.click();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Render should include opened_tabs (drains the queue)
+    const representation = await renderActivePage(deps, { source: "action" });
+    expect(representation.opened_tabs).toBeDefined();
+    expect(representation.opened_tabs!.length).toBe(1);
+
+    // Subsequent render should NOT include opened_tabs (single-consumption)
+    const representation2 = await renderActivePage(deps, { source: "action" });
+    expect(representation2.opened_tabs).toBeUndefined();
+  });
+
+  it("does not report opened_tabs for same-tab navigation", async () => {
+    const page = pageManager.getActivePage();
+
+    await waitForPossibleNavigation(page, async () => {
+      await page.click("#same-tab-link");
+    });
+
+    const newTabs = pageManager.consumeNewTabs();
+    expect(newTabs.length).toBe(0);
+  });
+
+  it("auto-cleans tabs when page closes itself", async () => {
+    const page = pageManager.getActivePage();
+
+    // Open a popup via window.open and capture a reference
+    await page.evaluate(() => {
+      (window as unknown as Record<string, unknown>)._popup = window.open("about:blank", "_blank");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const newTabs = pageManager.consumeNewTabs();
+    expect(newTabs.length).toBe(1);
+    const popupTabId = newTabs[0];
+
+    const tabsBefore = await pageManager.listTabs();
+    const popupTabExists = tabsBefore.some((t) => t.id === popupTabId);
+    expect(popupTabExists).toBe(true);
+
+    // Close the popup from the opener
+    await page.evaluate(() => {
+      ((window as unknown as Record<string, unknown>)._popup as Window).close();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Tab should have been auto-removed
+    const tabsAfter = await pageManager.listTabs();
+    const popupTabStillExists = tabsAfter.some((t) => t.id === popupTabId);
+    expect(popupTabStillExists).toBe(false);
+  });
+});

--- a/tests/sandbox/index.html
+++ b/tests/sandbox/index.html
@@ -36,6 +36,7 @@
     <a href="index.html">Home</a>
     <a href="forms.html">Forms</a>
     <a href="interactive.html">Interactive</a>
+    <a href="popups.html">Popups</a>
     <a href="about.html">About</a>
   </nav>
 

--- a/tests/sandbox/popups.html
+++ b/tests/sandbox/popups.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Popup and new tab testing page for Charlotte MCP">
+  <title>Popups - Charlotte Test Sandbox</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; line-height: 1.6; color: #333; }
+    header { background: #2563eb; color: white; padding: 1rem 2rem; }
+    nav { background: #1e40af; padding: 0.5rem 2rem; }
+    nav a { color: #93c5fd; margin-right: 1.5rem; text-decoration: none; }
+    main { padding: 2rem; max-width: 900px; }
+    h2 { margin-top: 1.5rem; margin-bottom: 0.75rem; }
+    p { margin-bottom: 1rem; }
+    section { margin-bottom: 2rem; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 8px; }
+    a.test-link { display: inline-block; margin: 0.25rem 0.5rem 0.25rem 0; padding: 0.4rem 0.8rem; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 4px; color: #1d4ed8; text-decoration: none; }
+    a.test-link:hover { background: #dbeafe; }
+    button { padding: 0.5rem 1rem; border: 1px solid #d1d5db; border-radius: 4px; cursor: pointer; font-size: 0.9rem; margin-right: 0.5rem; margin-bottom: 0.5rem; }
+    button:hover { background: #f3f4f6; }
+    .btn-primary { background: #2563eb; color: white; border-color: #2563eb; }
+    .btn-primary:hover { background: #1d4ed8; }
+    footer { background: #f3f4f6; padding: 1rem 2rem; margin-top: 2rem; border-top: 1px solid #e5e7eb; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Popup & New Tab Testing</h1>
+  </header>
+
+  <nav aria-label="Main navigation">
+    <a href="index.html">Home</a>
+    <a href="forms.html">Forms</a>
+    <a href="interactive.html">Interactive</a>
+    <a href="popups.html">Popups</a>
+    <a href="about.html">About</a>
+  </nav>
+
+  <main>
+    <h2>target="_blank" Links</h2>
+    <section>
+      <p>These links use <code>target="_blank"</code> and should open in new tabs. Charlotte should capture them automatically via the popup event handler.</p>
+      <a id="blank-about" class="test-link" href="about.html" target="_blank">About (new tab)</a>
+      <a id="blank-forms" class="test-link" href="forms.html" target="_blank">Forms (new tab)</a>
+      <a id="blank-interactive" class="test-link" href="interactive.html" target="_blank">Interactive (new tab)</a>
+    </section>
+
+    <h2>window.open()</h2>
+    <section>
+      <p>These buttons use <code>window.open()</code> to open pages programmatically.</p>
+      <button id="open-about" class="btn-primary" onclick="window.open('about.html', '_blank')">Open About</button>
+      <button id="open-forms" onclick="window.open('forms.html', '_blank')">Open Forms</button>
+    </section>
+
+    <h2>Same-tab Navigation (control)</h2>
+    <section>
+      <p>These links navigate in the same tab. No popup should be captured.</p>
+      <a id="same-tab-about" class="test-link" href="about.html">About (same tab)</a>
+      <a id="same-tab-forms" class="test-link" href="forms.html">Forms (same tab)</a>
+    </section>
+  </main>
+
+  <footer>
+    <p>Charlotte Test Sandbox - Popup Testing</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Clicks on `target="_blank"` links and `window.open()` calls were silently lost — the new tab was created by Puppeteer but never registered in PageManager
- Adds always-on `popup` event handler that auto-captures new pages as managed tabs
- Adds `close` event handler to auto-clean tabs closed by the page itself
- Surfaces `opened_tabs` in `PageRepresentation` using single-consumption semantics (same pattern as `DevModeState` reload events)
- No changes to `waitForPossibleNavigation` — popup capture is a page lifecycle concern handled entirely in `PageManager`

## Test plan
- [x] 5 new integration tests: target="_blank" capture, window.open() capture, opened_tabs in render response, same-tab navigation (no false positive), auto-cleanup on page close
- [x] All 508 tests pass (503 existing + 5 new)
- [x] Live-tested against Baidu search (the original reproduction from #98) — new tab captured and switchable

Fixes #103, fixes #98

// ticktockbent