### PR TITLE
Update docs and version for v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Charlotte will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-14
+
+### Added
+
+- **Popup and target="_blank" tab capture** — Clicks on `target="_blank"` links and `window.open()` calls were silently lost because PageManager had no `popup` event handler. New tabs are now auto-captured via `page.on("popup")`, auto-cleaned when pages close themselves, and surfaced as `opened_tabs` in tool responses using single-consumption semantics. Fixes #103, #98.
+- **Contributor issue templates** — Bug report, feature request, and tool request templates added to the repository. Community links added to README. (#102)
+
+### Changed
+
+- Renamed AXIOM to ASM across Charlotte site (#100).
+- Bumped hono dependency (#99).
+
 ## [0.5.0] - 2026-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charlotte decomposes each page into a typed, structured representation — landm
 
 ### Benchmarks
 
-Charlotte v0.5.0 vs Playwright MCP, measured by characters returned per tool call on real websites:
+Charlotte v0.5.1 vs Playwright MCP, measured by characters returned per tool call on real websites:
 
 **Navigation** (first contact with a page):
 
@@ -439,7 +439,7 @@ Charlotte includes a test website in `tests/sandbox/` that exercises all tools w
 dev_serve({ path: "tests/sandbox" })
 ```
 
-Four pages cover navigation, forms, interactive elements, delayed content, scroll containers, and more. See [docs/sandbox.md](docs/sandbox.md) for the full page reference and a tool-by-tool exercise checklist.
+Five pages cover navigation, forms, interactive elements, popups, delayed content, scroll containers, and more. See [docs/sandbox.md](docs/sandbox.md) for the full page reference and a tool-by-tool exercise checklist.
 
 ## Known Issues
 

--- a/docs/CHARLOTTE_SPEC.md
+++ b/docs/CHARLOTTE_SPEC.md
@@ -1,6 +1,6 @@
 # Charlotte Technical Specification
 
-**Version:** 0.5.0
+**Version:** 0.5.1
 
 Charlotte is an MCP server that renders web pages into structured, agent-readable `PageRepresentation` objects using headless Chromium and Puppeteer. It communicates over stdio using the Model Context Protocol.
 
@@ -71,7 +71,7 @@ Each render executes these stages in order:
 | `source` | `"observe" \| "action" \| "internal"` | `"action"` | Controls auto-snapshot behavior |
 | `forceSnapshot` | `boolean` | `false` | Override auto-snapshot decision |
 
-After rendering, it attaches console/network errors, optionally pushes a snapshot, and consumes any pending reload event from `DevModeState`. When a JavaScript dialog is blocking the page, returns a stub representation with `pending_dialog` instead of attempting to render (since CDP calls like `page.title()` hang while dialogs are open).
+After rendering, it attaches console/network errors, optionally pushes a snapshot, consumes any pending reload event from `DevModeState`, and drains any new tabs captured by the popup handler (surfaced as `opened_tabs`). When a JavaScript dialog is blocking the page, returns a stub representation with `pending_dialog` instead of attempting to render (since CDP calls like `page.title()` hang while dialogs are open).
 
 **`renderAfterAction(deps)`** — Used by interaction tools. Captures a pre-action snapshot, calls `renderActivePage` with `source: "action"`, computes a structural diff, and attaches the `delta` field to the response.
 
@@ -99,6 +99,7 @@ interface PageRepresentation {
   iframes?: IframeInfo[];                     // Present when child frames are discovered
   reload_event?: ReloadEvent;                // Present when dev_serve detects file changes
   pending_dialog?: PendingDialog;            // Present when a JS dialog is blocking
+  opened_tabs?: string[];                    // Tab IDs of pages opened by popups since the last tool call
   delta?: SnapshotDiff;                      // Present after interaction tools
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Token-efficient browser MCP server — structured web pages for AI agents, not raw accessibility dumps",
   "type": "module",
   "main": "dist/index.js",

--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -19,6 +19,15 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "0.5.1",
+    date: "2026-03-14",
+    entries: [
+      { type: "added", text: "Popup and target=\"_blank\" tab capture — Clicks on target=\"_blank\" links and window.open() now auto-capture the new tab in PageManager. Surfaced as opened_tabs in tool responses. Fixes #103, #98." },
+      { type: "added", text: "Contributor issue templates — Bug report, feature request, and tool request templates. Community links in README." },
+      { type: "changed", text: "Renamed AXIOM to ASM across Charlotte site." },
+    ],
+  },
+  {
     version: "0.5.0",
     date: "2026-03-09",
     entries: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,7 +77,7 @@ export function createServer(deps: ServerDeps, options: ServerOptions = {}): Cre
   const server = new McpServer(
     {
       name: "charlotte",
-      version: "0.5.0",
+      version: "0.5.1",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary
- Bump version to 0.5.1 in package.json and server.ts
- Add v0.5.1 CHANGELOG section (popup capture fix, community templates, AXIOM→ASM rename, hono bump)
- Update README benchmark header version and sandbox page count (4→5)
- Add `opened_tabs` field to spec `PageRepresentation` and `renderActivePage` docs
- Add v0.5.1 entry to site changelog

## Test plan
- [x] 508/508 tests pass
- [x] Type check clean

// ticktockbent