### PR TITLE
Fix CVE-2026-31988: override yauzl to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ticktockbent/charlotte",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -3755,15 +3755,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -6578,13 +6569,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
   "mcpName": "io.github.TickTockBent/charlotte",
   "publishConfig": {
     "access": "public"
+  },
+  "overrides": {
+    "yauzl": "3.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #21](https://github.com/TickTockBent/charlotte/security/dependabot/21) — off-by-one in yauzl's NTFS timestamp parser allows DoS via crafted zip (CVE-2026-31988)
- Adds npm `overrides` to pin `yauzl@3.2.1` (from 2.10.0), since upstream `extract-zip@2.0.1` constrains to `^2.10.0` and the fix is in 3.x
- yauzl 3.x public API is backward-compatible with extract-zip's usage — verified build + all 261 unit tests pass

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:unit` — 261/261 passing
- [ ] CI integration tests pass
- [ ] Dependabot alert #21 auto-closes after merge

// ticktockbent