### PR TITLE
Update docs and version for v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Charlotte will be documented in this file.
 
 <!-- Nothing yet -->
 
+## [0.6.1] - 2026-04-09
+
+### Fixed
+
+- **Runtime tool group activation** — Tools enabled via `charlotte_tools` were not callable by MCP clients. Each `tool.enable()` call triggered a separate `sendToolListChanged()` notification, flooding the client before the tool response was returned. Now batches state changes and sends a single notification per enable/disable action. Fixes #146. (#147)
+
+### Changed
+
+- Dependency updates: vite (#142), npm_and_yarn group (#144), basic-ftp (#145)
+
 ## [0.6.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charlotte decomposes each page into a typed, structured representation — landm
 
 ### Benchmarks
 
-Charlotte v0.6.0 vs Playwright MCP, measured by characters returned per tool call on real websites:
+Charlotte v0.6.1 vs Playwright MCP, measured by characters returned per tool call on real websites:
 
 **Navigation** (first contact with a page):
 

--- a/docs/CHARLOTTE_SPEC.md
+++ b/docs/CHARLOTTE_SPEC.md
@@ -1,6 +1,6 @@
 # Charlotte Technical Specification
 
-**Version:** 0.6.0
+**Version:** 0.6.1
 
 Charlotte is an MCP server that renders web pages into structured, agent-readable `PageRepresentation` objects using headless Chromium and Puppeteer. It communicates over stdio using the Model Context Protocol.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Token-efficient browser MCP server — structured web pages for AI agents, not raw accessibility dumps",
   "type": "module",
   "main": "dist/index.js",

--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -19,6 +19,13 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "0.6.1",
+    date: "2026-04-09",
+    entries: [
+      { type: "fixed", text: "Runtime tool group activation — Tools enabled via charlotte_tools were not callable by MCP clients due to notification flooding. Now sends a single batched notification per enable/disable action. Fixes #146." },
+    ],
+  },
+  {
     version: "0.6.0",
     date: "2026-04-03",
     entries: [


### PR DESCRIPTION
## Summary
- Bumps version to 0.6.1 in package.json, CHARLOTTE_SPEC.md, and README benchmark header
- Adds CHANGELOG entry for #146 fix and dependency bumps (#142, #144, #145)
- Adds v0.6.1 entry to site changelog

## Test plan
- [x] All 534 tests pass
- [x] Type-check clean
- [x] Cold-reviewed by sub-agent

// ticktockbent