### PR TITLE
fix: clean up stale frame sessions in CDPSessionManager

### DIFF
--- a/src/browser/cdp-session.ts
+++ b/src/browser/cdp-session.ts
@@ -9,6 +9,13 @@ const FRAME_DOMAINS = ["Accessibility", "DOM", "CSS"] as const;
 export class CDPSessionManager {
   private sessions: WeakMap<Page, CDPSession> = new WeakMap();
   private frameSessions = new Map<string, CDPSession>();
+  /** Reverse index: page → set of frameIds cached for that page. */
+  private pageFrameIds = new Map<Page, Set<string>>();
+
+  /** Number of cached frame sessions (for diagnostics/testing). */
+  get frameSessionCount(): number {
+    return this.frameSessions.size;
+  }
 
   async getSession(page: Page): Promise<CDPSession> {
     const existing = this.sessions.get(page);
@@ -37,18 +44,75 @@ export class CDPSessionManager {
     logger.debug("Creating CDP session for frame", { frameId, url: frame.url() });
     // CdpFrame exposes .client which is the CDP session for that frame's target.
     // This is a Puppeteer internal (tested with puppeteer 24.x). If Puppeteer
-    // changes the internal API, this will need updating.
-    const session = (frame as any).client as CDPSession;
+    // changes the internal API, this will need updating. See issue #84.
+    const client = (frame as any).client;
+    if (!client || typeof client.send !== "function") {
+      throw new Error(
+        `Puppeteer Frame.client is unavailable or not a CDPSession. ` +
+          `This Puppeteer version may have changed internal APIs. See issue #84.`,
+      );
+    }
+    const session = client as CDPSession;
     await this.enableDomains(session, FRAME_DOMAINS);
     this.frameSessions.set(frameId, session);
+
+    // Track page → frameId association for bulk cleanup on page close
+    const page = frame.page();
+    let ids = this.pageFrameIds.get(page);
+    if (!ids) {
+      ids = new Set();
+      this.pageFrameIds.set(page, ids);
+    }
+    ids.add(frameId);
+
     return session;
   }
 
   /** Extract the CDP frame ID from a Puppeteer Frame. */
   getFrameId(frame: Frame): string {
     // Puppeteer Frame exposes _id as the CDP frame ID.
-    // This is a Puppeteer internal (tested with puppeteer 24.x).
-    return (frame as any)._id as string;
+    // This is a Puppeteer internal (tested with puppeteer 24.x). See issue #84.
+    const id = (frame as any)._id;
+    if (typeof id !== "string" || id.length === 0) {
+      throw new Error(
+        `Puppeteer Frame._id is unavailable or empty. ` +
+          `This Puppeteer version may have changed internal APIs. See issue #84.`,
+      );
+    }
+    return id;
+  }
+
+  /**
+   * Remove a single frame session entry. Called when a frame detaches.
+   * The CDP session itself is owned by Puppeteer and detaches automatically
+   * when the frame target is destroyed — we only drop our cache entry.
+   */
+  removeFrameSession(frameId: string): void {
+    const removed = this.frameSessions.delete(frameId);
+    if (removed) {
+      // Also remove from reverse index
+      for (const ids of this.pageFrameIds.values()) {
+        ids.delete(frameId);
+      }
+      logger.debug("Removed stale frame session", { frameId });
+    }
+  }
+
+  /**
+   * Remove all frame sessions associated with a page.
+   * Called on page close for bulk cleanup.
+   */
+  clearPageFrameSessions(page: Page): void {
+    const ids = this.pageFrameIds.get(page);
+    if (!ids || ids.size === 0) {
+      this.pageFrameIds.delete(page);
+      return;
+    }
+    for (const frameId of ids) {
+      this.frameSessions.delete(frameId);
+    }
+    logger.debug(`Cleared ${ids.size} frame session(s) for closed page`);
+    this.pageFrameIds.delete(page);
   }
 
   private async enableDomains(session: CDPSession, domains: readonly string[]): Promise<void> {

--- a/src/browser/cdp-session.ts
+++ b/src/browser/cdp-session.ts
@@ -90,9 +90,12 @@ export class CDPSessionManager {
   removeFrameSession(frameId: string): void {
     const removed = this.frameSessions.delete(frameId);
     if (removed) {
-      // Also remove from reverse index
-      for (const ids of this.pageFrameIds.values()) {
+      // Also remove from reverse index; drop empty Sets to avoid dangling Page refs
+      for (const [page, ids] of this.pageFrameIds.entries()) {
         ids.delete(frameId);
+        if (ids.size === 0) {
+          this.pageFrameIds.delete(page);
+        }
       }
       logger.debug("Removed stale frame session", { frameId });
     }

--- a/src/browser/page-manager.ts
+++ b/src/browser/page-manager.ts
@@ -1,5 +1,6 @@
 import type { Page, Dialog } from "puppeteer";
 import type { BrowserManager } from "./browser-manager.js";
+import type { CDPSessionManager } from "./cdp-session.js";
 import type { PendingDialog } from "../types/page-representation.js";
 import { createDefaultConfig } from "../types/config.js";
 import type { CharlotteConfig } from "../types/config.js";
@@ -53,9 +54,12 @@ export class PageManager {
   /** Tab IDs of pages opened by popups since the last drain. */
   private newTabQueue: string[] = [];
 
-  constructor(config?: CharlotteConfig) {
+  private cdpSessionManager?: CDPSessionManager;
+
+  constructor(config?: CharlotteConfig, cdpSessionManager?: CDPSessionManager) {
     // Accept optional config; callers without config get a permissive default
     this.config = config ?? createDefaultConfig();
+    this.cdpSessionManager = cdpSessionManager;
   }
 
   /**
@@ -135,6 +139,19 @@ export class PageManager {
       }
     });
 
+    // Clean up stale frame session cache entries when a frame detaches.
+    // Fires for individual iframe removal AND for all child frames on full-page navigation.
+    if (this.cdpSessionManager) {
+      page.on("framedetached", (frame) => {
+        try {
+          const frameId = this.cdpSessionManager!.getFrameId(frame);
+          this.cdpSessionManager!.removeFrameSession(frameId);
+        } catch {
+          // Frame may already be destroyed — ignore errors in cleanup
+        }
+      });
+    }
+
     // Capture popups (target="_blank" links, window.open()) as managed tabs
     page.on("popup", (popupPage) => {
       if (popupPage) {
@@ -144,6 +161,9 @@ export class PageManager {
 
     // Auto-clean when a page closes itself (window.close(), site-initiated)
     page.on("close", () => {
+      if (this.cdpSessionManager) {
+        this.cdpSessionManager.clearPageFrameSessions(page);
+      }
       if (this.pages.has(tabId)) {
         this.pages.delete(tabId);
         logger.info(`Tab ${tabId} closed by page`);
@@ -230,10 +250,14 @@ export class PageManager {
       throw new CharlotteError(CharlotteErrorCode.SESSION_ERROR, `Tab '${tabId}' not found`);
     }
 
+    if (this.cdpSessionManager) {
+      this.cdpSessionManager.clearPageFrameSessions(managedPage.page);
+    }
     managedPage.page.removeAllListeners("console");
     managedPage.page.removeAllListeners("response");
     managedPage.page.removeAllListeners("dialog");
     managedPage.page.removeAllListeners("framenavigated");
+    managedPage.page.removeAllListeners("framedetached");
     managedPage.page.removeAllListeners("popup");
     managedPage.page.removeAllListeners("close");
     await managedPage.page.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,10 @@ async function main(): Promise<void> {
 
   // Initialize browser and page management (Chromium launched lazily on first tool call)
   const browserManager = new BrowserManager(config, { headless: cliOptions.headless });
-  const pageManager = new PageManager(config);
+  const cdpSessionManager = new CDPSessionManager();
+  const pageManager = new PageManager(config, cdpSessionManager);
 
   // Initialize renderer pipeline
-  const cdpSessionManager = new CDPSessionManager();
   const elementIdGenerator = new ElementIdGenerator();
   const rendererPipeline = new RendererPipeline(cdpSessionManager, elementIdGenerator, config);
   const snapshotStore = new SnapshotStore(config.snapshotDepth);

--- a/tests/integration/iframe.test.ts
+++ b/tests/integration/iframe.test.ts
@@ -32,9 +32,9 @@ describe("Iframe content extraction", () => {
 
     browserManager = new BrowserManager();
     await browserManager.launch();
-    pageManager = new PageManager();
-    await pageManager.openTab(browserManager);
     cdpSessionManager = new CDPSessionManager();
+    pageManager = new PageManager(undefined, cdpSessionManager);
+    await pageManager.openTab(browserManager);
     elementIdGenerator = new ElementIdGenerator();
 
     const config = createDefaultConfig();
@@ -219,5 +219,56 @@ describe("Iframe content extraction", () => {
 
     // Restore depth for subsequent tests
     deps.config.iframeDepth = 3;
+  });
+
+  describe("frame session cleanup", () => {
+    it("cleans up frame sessions when navigating away from an iframe page", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      // Render to trigger frame session creation
+      await renderActivePage(deps, { detail: "summary" });
+      expect(cdpSessionManager.frameSessionCount).toBeGreaterThan(0);
+
+      // Navigate to a non-iframe page — child frames detach
+      await page.goto(`${baseUrl}/simple.html`, { waitUntil: "load" });
+
+      // Frame sessions should be cleaned up via framedetached events
+      expect(cdpSessionManager.frameSessionCount).toBe(0);
+    });
+
+    it("cleans up frame sessions on tab close", async () => {
+      // Open a fresh tab for this test
+      const tabId = await pageManager.openTab(browserManager);
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      await renderActivePage(deps, { detail: "summary" });
+      expect(cdpSessionManager.frameSessionCount).toBeGreaterThan(0);
+
+      await pageManager.closeTab(tabId);
+
+      expect(cdpSessionManager.frameSessionCount).toBe(0);
+    });
+  });
+
+  describe("Puppeteer internals smoke test", () => {
+    it("Frame._id is a non-empty string", () => {
+      const page = pageManager.getActivePage();
+      const mainFrame = page.mainFrame();
+      const frameId = (mainFrame as any)._id;
+
+      expect(typeof frameId).toBe("string");
+      expect(frameId.length).toBeGreaterThan(0);
+    });
+
+    it("Frame.client is a CDPSession-like object with a send method", () => {
+      const page = pageManager.getActivePage();
+      const mainFrame = page.mainFrame();
+      const client = (mainFrame as any).client;
+
+      expect(client).toBeDefined();
+      expect(typeof client.send).toBe("function");
+    });
   });
 });

--- a/tests/unit/browser/cdp-session-manager.test.ts
+++ b/tests/unit/browser/cdp-session-manager.test.ts
@@ -89,9 +89,7 @@ describe("CDPSessionManager", () => {
       const frame = mockFrame("frame-bad", page, undefined);
       frame.client = undefined;
 
-      await expect(manager.getFrameSession(frame)).rejects.toThrow(
-        /Frame\.client is unavailable/,
-      );
+      await expect(manager.getFrameSession(frame)).rejects.toThrow(/Frame\.client is unavailable/);
     });
 
     it("throws when frame.client has no send method", async () => {
@@ -99,9 +97,7 @@ describe("CDPSessionManager", () => {
       const frame = mockFrame("frame-bad", page, undefined);
       frame.client = { notSend: true };
 
-      await expect(manager.getFrameSession(frame)).rejects.toThrow(
-        /Frame\.client is unavailable/,
-      );
+      await expect(manager.getFrameSession(frame)).rejects.toThrow(/Frame\.client is unavailable/);
     });
   });
 

--- a/tests/unit/browser/cdp-session-manager.test.ts
+++ b/tests/unit/browser/cdp-session-manager.test.ts
@@ -145,6 +145,20 @@ describe("CDPSessionManager", () => {
       expect(manager.frameSessionCount).toBe(0);
     });
 
+    it("cleans up empty reverse-index entries after all frames removed", async () => {
+      const page = mockPage();
+      await manager.getFrameSession(mockFrame("frame-1", page));
+      await manager.getFrameSession(mockFrame("frame-2", page));
+
+      manager.removeFrameSession("frame-1");
+      manager.removeFrameSession("frame-2");
+
+      // After removing all frames individually, clearPageFrameSessions
+      // should be a no-op (the page entry was already pruned)
+      manager.clearPageFrameSessions(page);
+      expect(manager.frameSessionCount).toBe(0);
+    });
+
     it("allows re-caching after removal", async () => {
       const page = mockPage();
       const clientA = mockCDPSession();

--- a/tests/unit/browser/cdp-session-manager.test.ts
+++ b/tests/unit/browser/cdp-session-manager.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { CDPSessionManager } from "../../../src/browser/cdp-session.js";
+
+// Lightweight mocks — no real browser needed for cache management tests.
+
+function mockPage(): any {
+  return { createCDPSession: vi.fn() };
+}
+
+function mockCDPSession(): any {
+  return { send: vi.fn().mockResolvedValue(undefined) };
+}
+
+function mockFrame(frameId: string, page: any, client?: any): any {
+  return {
+    _id: frameId,
+    client: client ?? mockCDPSession(),
+    page: () => page,
+    url: () => `https://example.com/frame/${frameId}`,
+  };
+}
+
+describe("CDPSessionManager", () => {
+  let manager: CDPSessionManager;
+
+  beforeEach(() => {
+    manager = new CDPSessionManager();
+  });
+
+  describe("getSession", () => {
+    it("creates and caches a session per page", async () => {
+      const page = mockPage();
+      const session = mockCDPSession();
+      page.createCDPSession.mockResolvedValue(session);
+
+      const firstCall = await manager.getSession(page);
+      const secondCall = await manager.getSession(page);
+
+      expect(firstCall).toBe(session);
+      expect(secondCall).toBe(session);
+      expect(page.createCDPSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates separate sessions for different pages", async () => {
+      const pageA = mockPage();
+      const pageB = mockPage();
+      const sessionA = mockCDPSession();
+      const sessionB = mockCDPSession();
+      pageA.createCDPSession.mockResolvedValue(sessionA);
+      pageB.createCDPSession.mockResolvedValue(sessionB);
+
+      const resultA = await manager.getSession(pageA);
+      const resultB = await manager.getSession(pageB);
+
+      expect(resultA).toBe(sessionA);
+      expect(resultB).toBe(sessionB);
+    });
+  });
+
+  describe("getFrameSession", () => {
+    it("caches frame sessions by frameId", async () => {
+      const page = mockPage();
+      const client = mockCDPSession();
+      const frame = mockFrame("frame-1", page, client);
+
+      const firstCall = await manager.getFrameSession(frame);
+      const secondCall = await manager.getFrameSession(frame);
+
+      expect(firstCall).toBe(client);
+      expect(secondCall).toBe(client);
+      // enableDomains calls send for each domain (Accessibility, DOM, CSS)
+      expect(client.send).toHaveBeenCalledTimes(3);
+    });
+
+    it("tracks frameSessionCount", async () => {
+      const page = mockPage();
+
+      expect(manager.frameSessionCount).toBe(0);
+
+      await manager.getFrameSession(mockFrame("frame-1", page));
+      expect(manager.frameSessionCount).toBe(1);
+
+      await manager.getFrameSession(mockFrame("frame-2", page));
+      expect(manager.frameSessionCount).toBe(2);
+    });
+
+    it("throws when frame.client is missing", async () => {
+      const page = mockPage();
+      const frame = mockFrame("frame-bad", page, undefined);
+      frame.client = undefined;
+
+      await expect(manager.getFrameSession(frame)).rejects.toThrow(
+        /Frame\.client is unavailable/,
+      );
+    });
+
+    it("throws when frame.client has no send method", async () => {
+      const page = mockPage();
+      const frame = mockFrame("frame-bad", page, undefined);
+      frame.client = { notSend: true };
+
+      await expect(manager.getFrameSession(frame)).rejects.toThrow(
+        /Frame\.client is unavailable/,
+      );
+    });
+  });
+
+  describe("getFrameId", () => {
+    it("returns the frame _id", () => {
+      const frame = mockFrame("abc-123", mockPage());
+      expect(manager.getFrameId(frame)).toBe("abc-123");
+    });
+
+    it("throws when _id is missing", () => {
+      const frame = { _id: undefined } as any;
+      expect(() => manager.getFrameId(frame)).toThrow(/Frame\._id is unavailable/);
+    });
+
+    it("throws when _id is empty string", () => {
+      const frame = { _id: "" } as any;
+      expect(() => manager.getFrameId(frame)).toThrow(/Frame\._id is unavailable/);
+    });
+
+    it("throws when _id is not a string", () => {
+      const frame = { _id: 42 } as any;
+      expect(() => manager.getFrameId(frame)).toThrow(/Frame\._id is unavailable/);
+    });
+  });
+
+  describe("removeFrameSession", () => {
+    it("removes a single cached frame session", async () => {
+      const page = mockPage();
+      await manager.getFrameSession(mockFrame("frame-1", page));
+      await manager.getFrameSession(mockFrame("frame-2", page));
+
+      expect(manager.frameSessionCount).toBe(2);
+
+      manager.removeFrameSession("frame-1");
+
+      expect(manager.frameSessionCount).toBe(1);
+    });
+
+    it("is a no-op for unknown frameId", () => {
+      manager.removeFrameSession("nonexistent");
+      expect(manager.frameSessionCount).toBe(0);
+    });
+
+    it("allows re-caching after removal", async () => {
+      const page = mockPage();
+      const clientA = mockCDPSession();
+      const clientB = mockCDPSession();
+
+      await manager.getFrameSession(mockFrame("frame-1", page, clientA));
+      manager.removeFrameSession("frame-1");
+
+      const reacquired = await manager.getFrameSession(mockFrame("frame-1", page, clientB));
+      expect(reacquired).toBe(clientB);
+    });
+  });
+
+  describe("clearPageFrameSessions", () => {
+    it("removes all frame sessions for a specific page", async () => {
+      const pageA = mockPage();
+      const pageB = mockPage();
+
+      await manager.getFrameSession(mockFrame("frame-a1", pageA));
+      await manager.getFrameSession(mockFrame("frame-a2", pageA));
+      await manager.getFrameSession(mockFrame("frame-b1", pageB));
+
+      expect(manager.frameSessionCount).toBe(3);
+
+      manager.clearPageFrameSessions(pageA);
+
+      expect(manager.frameSessionCount).toBe(1);
+    });
+
+    it("does not affect sessions from other pages", async () => {
+      const pageA = mockPage();
+      const pageB = mockPage();
+      const clientB = mockCDPSession();
+
+      await manager.getFrameSession(mockFrame("frame-a1", pageA));
+      await manager.getFrameSession(mockFrame("frame-b1", pageB, clientB));
+
+      manager.clearPageFrameSessions(pageA);
+
+      // pageB's session should still be cached
+      const frame = mockFrame("frame-b1", pageB, clientB);
+      const result = await manager.getFrameSession(frame);
+      expect(result).toBe(clientB);
+    });
+
+    it("is idempotent — safe to call twice", async () => {
+      const page = mockPage();
+      await manager.getFrameSession(mockFrame("frame-1", page));
+
+      manager.clearPageFrameSessions(page);
+      manager.clearPageFrameSessions(page);
+
+      expect(manager.frameSessionCount).toBe(0);
+    });
+
+    it("is safe to call on a page with no frame sessions", () => {
+      const page = mockPage();
+      manager.clearPageFrameSessions(page);
+      expect(manager.frameSessionCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #67
Relates to #84

## Summary

- `CDPSessionManager.frameSessions` (`Map<string, CDPSession>`) grew unboundedly as iframes were discovered but was never cleaned up when frames navigated away or were removed. This adds event-driven cleanup so entries are pruned automatically.
- Adds runtime guards on Puppeteer internal access (`Frame._id`, `Frame.client`) with descriptive errors referencing #84, plus integration smoke tests that validate these internals still exist.

## Changes

- **`src/browser/cdp-session.ts`** — `removeFrameSession()`, `clearPageFrameSessions()`, `frameSessionCount` getter, reverse page-to-frameId index, runtime validation of Puppeteer internals
- **`src/browser/page-manager.ts`** — Accepts optional `CDPSessionManager`; registers `framedetached` listener for per-frame cleanup; calls bulk cleanup on page close and `closeTab()`
- **`src/index.ts`** — Reordered instantiation to pass `CDPSessionManager` to `PageManager`
- **`tests/unit/browser/cdp-session-manager.test.ts`** — 17 new unit tests (caching, cleanup, idempotency, runtime guards)
- **`tests/integration/iframe.test.ts`** — 4 new tests (cleanup on navigation, cleanup on tab close, Puppeteer internals smoke tests)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test:unit` — 292 tests pass (17 new)
- [x] `npm run test:integration` — 263 tests pass (4 new), all existing iframe tests unaffected
- [x] Verified no intersection with PR #153 (CDP endpoint) — different files

// ticktockbent