### PR TITLE
test: add mixed-state group enable/disable tests (#149)

### DIFF
--- a/tests/unit/tools/meta-tool.test.ts
+++ b/tests/unit/tools/meta-tool.test.ts
@@ -166,6 +166,49 @@ describe("meta-tool", () => {
       expect(sendToolListChangedSpy).not.toHaveBeenCalled();
     });
 
+    it("sends one notification when enabling a partially-disabled group", async () => {
+      const sessionTools = TOOL_GROUPS.session;
+      // Disable only the first half of the group
+      const disabledTools = sessionTools.slice(0, Math.floor(sessionTools.length / 2));
+      for (const toolName of disabledTools) {
+        registry[toolName].enabled = false;
+      }
+
+      const result = await metaTool.handler({ action: "enable", group: "session" }, {} as any);
+      const parsed = JSON.parse((result as any).content[0].text);
+
+      // Only the previously-disabled tools should count as enabled
+      expect(parsed.tools_enabled).toBe(disabledTools.length);
+      // Exactly one notification for the batch
+      expect(sendToolListChangedSpy).toHaveBeenCalledTimes(1);
+      // All tools in the group should now be enabled
+      for (const toolName of sessionTools) {
+        expect(registry[toolName].enabled).toBe(true);
+      }
+    });
+
+    it("sends one notification when disabling a partially-enabled group", async () => {
+      const sessionTools = TOOL_GROUPS.session;
+      // Disable the second half so only the first half is still enabled
+      const alreadyDisabled = sessionTools.slice(Math.floor(sessionTools.length / 2));
+      for (const toolName of alreadyDisabled) {
+        registry[toolName].enabled = false;
+      }
+      const stillEnabledCount = sessionTools.length - alreadyDisabled.length;
+
+      const result = await metaTool.handler({ action: "disable", group: "session" }, {} as any);
+      const parsed = JSON.parse((result as any).content[0].text);
+
+      // Only the previously-enabled tools should count as disabled
+      expect(parsed.tools_disabled).toBe(stillEnabledCount);
+      // Exactly one notification for the batch
+      expect(sendToolListChangedSpy).toHaveBeenCalledTimes(1);
+      // All tools in the group should now be disabled
+      for (const toolName of sessionTools) {
+        expect(registry[toolName].enabled).toBe(false);
+      }
+    });
+
     it("does not call individual tool enable/disable methods", async () => {
       for (const toolName of TOOL_GROUPS.session) {
         registry[toolName].enabled = false;


### PR DESCRIPTION
## Summary
- Closes #149 — adds the missing mixed-state test case identified during review of #147
- Two new tests in the `tool list change notifications (#146)` describe block:
  - **Partially-disabled group → enable**: disables half the session tools, enables the group, asserts `tools_enabled` counts only the previously-disabled tools, exactly one `sendToolListChanged()` notification
  - **Partially-enabled group → disable**: mirror case for the disable path

## Test plan
- [x] `npx vitest run tests/unit/tools/meta-tool.test.ts` — all 15 tests pass (was 13)
- [x] `npx tsc --noEmit` not needed (test-only change, no type changes)

// ticktockbent