### PR TITLE
fix: batch startup tool.disable() into single sendToolListChanged()

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -128,11 +128,19 @@ export function createServer(deps: ServerDeps, options: ServerOptions = {}): Cre
   Object.assign(registry, registerDevModeTools(server, toolDeps));
 
   // ─── Apply profile: disable tools not in the enabled set ───
+  // Set .enabled directly to batch state changes before a single
+  // sendToolListChanged(). Do not call tool.disable() here — each
+  // call fires an independent notification via the SDK's update().
 
+  let disabledCount = 0;
   for (const [toolName, tool] of Object.entries(registry)) {
     if (!enabledTools.has(toolName)) {
-      tool.disable();
+      tool.enabled = false;
+      disabledCount++;
     }
+  }
+  if (disabledCount > 0) {
+    server.sendToolListChanged();
   }
 
   // ─── Register meta-tool (always enabled) ───


### PR DESCRIPTION
## Summary
- Replaces per-tool `tool.disable()` calls during startup with direct `tool.enabled = false` assignments followed by a single `server.sendToolListChanged()`
- Matches the batched notification pattern established in the meta-tool by #147

Closes #148

## Test plan
- [x] Existing `create-server.test.ts` tests pass (8/8)
- [x] Type check passes (`tsc --noEmit`)

// ticktockbent