### PR TITLE
feat: enable interaction with iframe elements

### DIFF
--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -502,7 +502,15 @@ export function registerInteractionTools(
         await ensureReady(deps);
         const sourceResolved = await resolveElement(deps, source_id);
         const targetResolved = await resolveElement(deps, target_id);
-        // Use source element's session — both elements must be in the same frame for drag
+
+        if (sourceResolved.frameId !== targetResolved.frameId) {
+          throw new CharlotteError(
+            CharlotteErrorCode.SESSION_ERROR,
+            "Cannot drag between different frames — source and target must be in the same frame.",
+            "Use charlotte_find to locate elements within the same frame.",
+          );
+        }
+
         const session = await getSessionForElement(deps, sourceResolved);
 
         logger.info("Dragging element", { source_id, target_id });

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -11,6 +11,7 @@ import {
   renderActivePage,
   renderAfterAction,
   resolveElement,
+  getSessionForElement,
   formatPageResponse,
   handleToolError,
   coercedBoolean,
@@ -61,7 +62,8 @@ export function registerInteractionTools(
     async ({ element_id, click_type, modifiers }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
         const clickVariant = click_type ?? "left";
         const activeModifiers = modifiers ?? [];
 
@@ -71,8 +73,14 @@ export function registerInteractionTools(
           modifiers: activeModifiers,
         });
 
-        await waitForPossibleNavigation(page, () =>
-          clickElementByBackendNodeId(page, backendNodeId, clickVariant, activeModifiers),
+        await waitForPossibleNavigation(resolved.page, () =>
+          clickElementByBackendNodeId(
+            resolved.page,
+            resolved.backendNodeId,
+            clickVariant,
+            activeModifiers,
+            session,
+          ),
         );
 
         const representation = await renderAfterAction(deps);
@@ -188,7 +196,8 @@ export function registerInteractionTools(
     async ({ element_id, text, clear_first, press_enter, slowly, character_delay }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
         const shouldClearFirst = clear_first ?? true;
         const shouldPressEnter = press_enter ?? false;
         const delayMs = character_delay ?? (slowly ? 50 : undefined);
@@ -202,12 +211,13 @@ export function registerInteractionTools(
         });
 
         await typeIntoElement(
-          page,
-          backendNodeId,
+          resolved.page,
+          resolved.backendNodeId,
           text,
           shouldClearFirst,
           shouldPressEnter,
           delayMs,
+          session,
         );
 
         const representation = await renderAfterAction(deps);
@@ -232,11 +242,12 @@ export function registerInteractionTools(
     async ({ element_id, value }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
 
         logger.info("Selecting option", { element_id, value });
 
-        await selectOptionByBackendNodeId(page, backendNodeId, value);
+        await selectOptionByBackendNodeId(resolved.page, resolved.backendNodeId, value, session);
 
         const representation = await renderAfterAction(deps);
         return formatPageResponse(representation);
@@ -259,12 +270,19 @@ export function registerInteractionTools(
     async ({ element_id }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
 
         logger.info("Toggling element", { element_id });
 
         // Toggle by clicking the element
-        await clickElementByBackendNodeId(page, backendNodeId, "left");
+        await clickElementByBackendNodeId(
+          resolved.page,
+          resolved.backendNodeId,
+          "left",
+          [],
+          session,
+        );
 
         await new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -307,25 +325,27 @@ export function registerInteractionTools(
         // If the form has a submit button, click it
         if (form.submit) {
           const submitResolved = await resolveElement(deps, form.submit);
+          const submitSession = await getSessionForElement(deps, submitResolved);
           logger.info("Submitting form via submit button", {
             form_id,
             submitButton: form.submit,
           });
           await waitForPossibleNavigation(page, () =>
-            clickElementByBackendNodeId(page, submitResolved.backendNodeId, "left"),
+            clickElementByBackendNodeId(
+              submitResolved.page,
+              submitResolved.backendNodeId,
+              "left",
+              [],
+              submitSession,
+            ),
           );
         } else {
           // Fall back to dispatching submit event on the form itself
-          const formBackendNodeId = deps.elementIdGenerator.resolveId(form_id);
-          if (formBackendNodeId === null) {
-            throw new CharlotteError(
-              CharlotteErrorCode.ELEMENT_NOT_FOUND,
-              `Could not resolve form '${form_id}' to a DOM element.`,
-            );
-          }
+          const formResolved = await resolveElement(deps, form_id);
+          const formSession = await getSessionForElement(deps, formResolved);
           logger.info("Submitting form via submit event", { form_id });
           await waitForPossibleNavigation(page, () =>
-            submitFormByBackendNodeId(page, formBackendNodeId),
+            submitFormByBackendNodeId(formResolved.page, formResolved.backendNodeId, formSession),
           );
         }
 
@@ -403,23 +423,19 @@ export function registerInteractionTools(
 
         if (element_id) {
           // Scroll within a specific container
-          const { backendNodeId } = await resolveElement(deps, element_id);
-          const cdpSession = await page.createCDPSession();
-          try {
-            const { object } = await cdpSession.send("DOM.resolveNode", {
-              backendNodeId,
+          const resolved = await resolveElement(deps, element_id);
+          const cdpSession = await getSessionForElement(deps, resolved);
+          const { object } = await cdpSession.send("DOM.resolveNode", {
+            backendNodeId: resolved.backendNodeId,
+          });
+          if (object?.objectId) {
+            await cdpSession.send("Runtime.callFunctionOn", {
+              objectId: object.objectId,
+              functionDeclaration: `function(dx, dy) {
+                this.scrollBy(dx, dy);
+              }`,
+              arguments: [{ value: deltaX }, { value: deltaY }],
             });
-            if (object?.objectId) {
-              await cdpSession.send("Runtime.callFunctionOn", {
-                objectId: object.objectId,
-                functionDeclaration: `function(dx, dy) {
-                  this.scrollBy(dx, dy);
-                }`,
-                arguments: [{ value: deltaX }, { value: deltaY }],
-              });
-            }
-          } finally {
-            await cdpSession.detach();
           }
         } else {
           // Scroll the page
@@ -455,11 +471,12 @@ export function registerInteractionTools(
     async ({ element_id }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
 
         logger.info("Hovering element", { element_id });
 
-        await hoverElementByBackendNodeId(page, backendNodeId);
+        await hoverElementByBackendNodeId(resolved.page, resolved.backendNodeId, session);
 
         const representation = await renderAfterAction(deps);
         return formatPageResponse(representation);
@@ -483,12 +500,19 @@ export function registerInteractionTools(
     async ({ source_id, target_id }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId: sourceNodeId } = await resolveElement(deps, source_id);
-        const { backendNodeId: targetNodeId } = await resolveElement(deps, target_id);
+        const sourceResolved = await resolveElement(deps, source_id);
+        const targetResolved = await resolveElement(deps, target_id);
+        // Use source element's session — both elements must be in the same frame for drag
+        const session = await getSessionForElement(deps, sourceResolved);
 
         logger.info("Dragging element", { source_id, target_id });
 
-        await dragElementToElement(page, sourceNodeId, targetNodeId);
+        await dragElementToElement(
+          sourceResolved.page,
+          sourceResolved.backendNodeId,
+          targetResolved.backendNodeId,
+          session,
+        );
 
         // Brief settle for DOM updates after drop
         await new Promise((resolve) => setTimeout(resolve, 100));
@@ -562,8 +586,9 @@ export function registerInteractionTools(
 
         // Focus target element if specified
         if (element_id) {
-          const { page: resolvedPage, backendNodeId } = await resolveElement(deps, element_id);
-          await focusElementByBackendNodeId(resolvedPage, backendNodeId);
+          const resolved = await resolveElement(deps, element_id);
+          const session = await getSessionForElement(deps, resolved);
+          await focusElementByBackendNodeId(resolved.page, resolved.backendNodeId, session);
         }
 
         if (key) {
@@ -619,7 +644,8 @@ export function registerInteractionTools(
     async ({ element_id, paths }) => {
       try {
         await ensureReady(deps);
-        const { page, backendNodeId } = await resolveElement(deps, element_id);
+        const resolved = await resolveElement(deps, element_id);
+        const session = await getSessionForElement(deps, resolved);
 
         // Validate all files exist before sending to CDP
         for (const filePath of paths) {
@@ -636,7 +662,7 @@ export function registerInteractionTools(
 
         logger.info("Uploading files", { element_id, fileCount: paths.length });
 
-        await setFileInputFiles(page, backendNodeId, paths);
+        await setFileInputFiles(resolved.page, resolved.backendNodeId, paths, session);
 
         const representation = await renderAfterAction(deps);
         return formatPageResponse(representation);
@@ -690,6 +716,7 @@ export function registerInteractionTools(
         // Validate all fields up front before performing any actions
         const resolvedFields: Array<{
           backendNodeId: number;
+          frameId: string | null;
           type: string;
           value: string;
           page: import("puppeteer").Page;
@@ -724,6 +751,7 @@ export function registerInteractionTools(
           const resolved = await resolveElement(deps, field.element_id);
           resolvedFields.push({
             backendNodeId: resolved.backendNodeId,
+            frameId: resolved.frameId,
             type: element.type,
             value: field.value,
             page: resolved.page,
@@ -734,20 +762,44 @@ export function registerInteractionTools(
 
         // Fill each field using the appropriate action
         for (const field of resolvedFields) {
+          const fieldSession = await getSessionForElement(deps, {
+            page: field.page,
+            backendNodeId: field.backendNodeId,
+            frameId: field.frameId,
+          });
           switch (field.type) {
             case "text_input":
             case "textarea":
             case "date_input":
             case "color_input":
-              await typeIntoElement(field.page, field.backendNodeId, field.value, true, false);
+              await typeIntoElement(
+                field.page,
+                field.backendNodeId,
+                field.value,
+                true,
+                false,
+                undefined,
+                fieldSession,
+              );
               break;
             case "select":
-              await selectOptionByBackendNodeId(field.page, field.backendNodeId, field.value);
+              await selectOptionByBackendNodeId(
+                field.page,
+                field.backendNodeId,
+                field.value,
+                fieldSession,
+              );
               break;
             case "checkbox":
             case "radio":
             case "toggle":
-              await clickElementByBackendNodeId(field.page, field.backendNodeId, "left");
+              await clickElementByBackendNodeId(
+                field.page,
+                field.backendNodeId,
+                "left",
+                [],
+                fieldSession,
+              );
               break;
           }
         }

--- a/tests/fixtures/pages/iframe-child.html
+++ b/tests/fixtures/pages/iframe-child.html
@@ -13,6 +13,15 @@
     <form>
       <label for="iframe-input">Iframe Input</label>
       <input type="text" id="iframe-input" name="iframe-input">
+      <label for="iframe-select">Iframe Select</label>
+      <select id="iframe-select" name="iframe-select">
+        <option value="">Choose...</option>
+        <option value="alpha">Alpha</option>
+        <option value="beta">Beta</option>
+        <option value="gamma">Gamma</option>
+      </select>
+      <label for="iframe-checkbox">Iframe Checkbox</label>
+      <input type="checkbox" id="iframe-checkbox" name="iframe-checkbox">
     </form>
     <iframe src="iframe-grandchild.html" width="400" height="200" title="Nested Iframe"></iframe>
   </main>

--- a/tests/integration/iframe.test.ts
+++ b/tests/integration/iframe.test.ts
@@ -11,7 +11,18 @@ import { ArtifactStore } from "../../src/state/artifact-store.js";
 import { createDefaultConfig } from "../../src/types/config.js";
 import { StaticServer } from "../../src/dev/static-server.js";
 import type { ToolDependencies } from "../../src/tools/tool-helpers.js";
-import { renderActivePage, resolveElement } from "../../src/tools/tool-helpers.js";
+import {
+  renderActivePage,
+  resolveElement,
+  getSessionForElement,
+} from "../../src/tools/tool-helpers.js";
+import {
+  clickElementByBackendNodeId,
+  hoverElementByBackendNodeId,
+  typeIntoElement,
+  selectOptionByBackendNodeId,
+  focusElementByBackendNodeId,
+} from "../../src/tools/interaction-helpers.js";
 
 const FIXTURES_DIR = path.resolve(import.meta.dirname, "../fixtures/pages");
 
@@ -249,6 +260,133 @@ describe("Iframe content extraction", () => {
       await pageManager.closeTab(tabId);
 
       expect(cdpSessionManager.frameSessionCount).toBe(0);
+    });
+  });
+
+  describe("Iframe element interaction", () => {
+    it("clicks a button inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeButton = representation.interactive.find((el) => el.label === "Iframe Button");
+      expect(iframeButton).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeButton!.id);
+      expect(resolved.frameId).toBeTruthy();
+
+      const session = await getSessionForElement(deps, resolved);
+      // Should not throw — clicking an iframe element via frame-specific session
+      await clickElementByBackendNodeId(resolved.page, resolved.backendNodeId, "left", [], session);
+    });
+
+    it("types into an input inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeInput = representation.interactive.find((el) => el.label === "Iframe Input");
+      expect(iframeInput).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeInput!.id);
+      const session = await getSessionForElement(deps, resolved);
+
+      await typeIntoElement(
+        resolved.page,
+        resolved.backendNodeId,
+        "hello from iframe",
+        true,
+        false,
+        undefined,
+        session,
+      );
+
+      // Verify the value was typed into the iframe input
+      const childFrame = page.frames().find((f) => f.url().includes("iframe-child.html"));
+      expect(childFrame).toBeDefined();
+      const inputValue = await childFrame!.evaluate(() => {
+        const input = document.getElementById("iframe-input") as HTMLInputElement;
+        return input?.value ?? "";
+      });
+      expect(inputValue).toBe("hello from iframe");
+    });
+
+    it("selects an option in a select inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeSelect = representation.interactive.find((el) => el.label === "Iframe Select");
+      expect(iframeSelect).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeSelect!.id);
+      const session = await getSessionForElement(deps, resolved);
+
+      await selectOptionByBackendNodeId(resolved.page, resolved.backendNodeId, "beta", session);
+
+      // Verify the value was selected
+      const childFrame = page.frames().find((f) => f.url().includes("iframe-child.html"));
+      expect(childFrame).toBeDefined();
+      const selectedValue = await childFrame!.evaluate(() => {
+        const select = document.getElementById("iframe-select") as HTMLSelectElement;
+        return select?.value ?? "";
+      });
+      expect(selectedValue).toBe("beta");
+    });
+
+    it("toggles a checkbox inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeCheckbox = representation.interactive.find(
+        (el) => el.label === "Iframe Checkbox",
+      );
+      expect(iframeCheckbox).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeCheckbox!.id);
+      const session = await getSessionForElement(deps, resolved);
+
+      // Click to check
+      await clickElementByBackendNodeId(resolved.page, resolved.backendNodeId, "left", [], session);
+
+      const childFrame = page.frames().find((f) => f.url().includes("iframe-child.html"));
+      expect(childFrame).toBeDefined();
+      const isChecked = await childFrame!.evaluate(() => {
+        const checkbox = document.getElementById("iframe-checkbox") as HTMLInputElement;
+        return checkbox?.checked ?? false;
+      });
+      expect(isChecked).toBe(true);
+    });
+
+    it("hovers over an element inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeButton = representation.interactive.find((el) => el.label === "Iframe Button");
+      expect(iframeButton).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeButton!.id);
+      const session = await getSessionForElement(deps, resolved);
+
+      // Should not throw
+      await hoverElementByBackendNodeId(resolved.page, resolved.backendNodeId, session);
+    });
+
+    it("focuses an element inside an iframe", async () => {
+      const page = pageManager.getActivePage();
+      await page.goto(`${baseUrl}/iframe-parent.html`, { waitUntil: "networkidle0" });
+
+      const representation = await renderActivePage(deps, { detail: "summary" });
+      const iframeInput = representation.interactive.find((el) => el.label === "Iframe Input");
+      expect(iframeInput).toBeDefined();
+
+      const resolved = await resolveElement(deps, iframeInput!.id);
+      const session = await getSessionForElement(deps, resolved);
+
+      // Should not throw
+      await focusElementByBackendNodeId(resolved.page, resolved.backendNodeId, session);
     });
   });
 


### PR DESCRIPTION
## Summary
- Wire `getSessionForElement()` into all 14 interaction tool call sites in `interaction.ts` so iframe elements receive the correct frame-specific CDP session
- Tools updated: `charlotte_click`, `charlotte_type`, `charlotte_select`, `charlotte_toggle`, `charlotte_submit`, `charlotte_scroll`, `charlotte_hover`, `charlotte_drag`, `charlotte_key`, `charlotte_upload`, `charlotte_fill_form`
- `charlotte_scroll` no longer creates/detaches throwaway CDP sessions — uses the managed session from `getSessionForElement`
- `charlotte_submit` form-event fallback now calls `resolveElement` instead of `resolveId` to get frameId
- `charlotte_fill_form` preserves `frameId` in its resolvedFields array

Closes #66.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 295/295 passing
- [x] Iframe integration tests — 18/18 passing (6 new interaction tests)
  - [x] Click button inside iframe
  - [x] Type into input inside iframe (value verified via frame eval)
  - [x] Select option in select inside iframe (value verified)
  - [x] Toggle checkbox inside iframe (checked state verified)
  - [x] Hover over element inside iframe
  - [x] Focus element inside iframe

// ticktockbent