### PR TITLE
Release prep: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to Charlotte will be documented in this file.
 
 <!-- Nothing yet -->
 
+## [0.6.2] - 2026-04-16
+
+### Added
+
+- **`--cdp-endpoint` CLI option** — Connect to a running Chrome/Chromium instance via its DevTools Protocol endpoint instead of launching a new browser. Supports raw `ws://` URLs and a `channel:chrome` shorthand that auto-discovers the endpoint. `BrowserManager` gains a connected mode that uses `puppeteer.connect()`, and `PageManager.adoptExistingPages()` picks up pre-existing tabs. Closes GAP-33. (#153)
+- **Iframe interaction** — Interaction tools (click, type, select, toggle, submit, scroll, hover, key, wait_for, upload, fill_form) now work against elements inside child frames. Complements the iframe content extraction added in v0.5.0, so agents can both see and act on iframe contents. Closes #66. (#160)
+- **CI workflow** — GitHub Actions workflow runs lint, typecheck, and full test suite on push and PR. Closes #56, #58. (#154)
+- **End-to-end MCP protocol tests** — New test suite exercises the server over an in-memory MCP transport to catch protocol-level regressions. Closes #60. (#156)
+
+### Changed
+
+- **Reduced CDP session churn** — Interaction helpers no longer repeatedly attach/detach CDP sessions. Sessions are reused across calls, cutting per-action overhead. Closes #113. (#159)
+- Applied Prettier formatting across all source and test files.
+- Dependency updates: hono (#161), next (#152), basic-ftp (#151).
+
+### Fixed
+
+- **Cross-frame drag validation** — `charlotte_drag` now validates that source and target elements belong to the same frame and surfaces a `CharlotteError` instead of producing undefined mouse behavior. (#160)
+- **Stale frame sessions in `CDPSessionManager`** — Frame sessions are now cleaned up when frames detach, and empty reverse-index entries are pruned. Prevents leaks when navigating pages with many iframes. Closes #67. (#155)
+- **Batched startup `tool.disable()`** — Disabling tools at startup based on profile no longer floods the client with a `sendToolListChanged()` notification per tool. Mirrors the batching fix for runtime enable/disable in v0.6.1. (#158)
+- **Viewport preserved on CDP connect** — When connecting via `--cdp-endpoint`, Charlotte no longer overrides the viewport of pages already open in the target browser.
+
+### Internal
+
+- Mixed-state group enable/disable tests added to cover partial-enable scenarios in the meta-tool. Closes #149. (#157)
+
 ## [0.6.1] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charlotte decomposes each page into a typed, structured representation — landm
 
 ### Benchmarks
 
-Charlotte v0.6.1 vs Playwright MCP, measured by characters returned per tool call on real websites:
+Charlotte v0.6.2 vs Playwright MCP, measured by characters returned per tool call on real websites:
 
 **Navigation** (first contact with a page):
 
@@ -71,7 +71,7 @@ Agents receive landmarks, headings, interactive elements with typed metadata, bo
 
 **Observation** — `observe` (3 detail levels, structural tree view), `find` (spatial + semantic search, CSS selector mode), `screenshot` (with persistent artifact management), `screenshots`, `screenshot_get`, `screenshot_delete`, `diff` (structural comparison against snapshots)
 
-**Interaction** — `click`, `click_at` (coordinate-based), `type` (with slow typing support), `select`, `toggle`, `submit`, `scroll`, `hover`, `drag`, `key` (single/sequence with element targeting), `wait_for` (async condition polling), `upload` (file input), `fill_form` (batch form fill), `dialog` (accept/dismiss JS dialogs)
+**Interaction** (iframe-aware) — `click`, `click_at` (coordinate-based), `type` (with slow typing support), `select`, `toggle`, `submit`, `scroll`, `hover`, `drag`, `key` (single/sequence with element targeting), `wait_for` (async condition polling), `upload` (file input), `fill_form` (batch form fill), `dialog` (accept/dismiss JS dialogs)
 
 **Monitoring** — `console` (all severity levels, filtering, timestamps), `requests` (full HTTP history, method/status/resource type filtering)
 
@@ -448,8 +448,6 @@ Five pages cover navigation, forms, interactive elements, popups, delayed conten
 ## Roadmap
 
 ### Session & Configuration
-
-**Connect to Existing Browser** — Add a `--cdp-endpoint` CLI argument so Charlotte can attach to an already-running browser via `puppeteer.connect()` instead of always launching a new instance. Enables working with logged-in sessions and browser extensions.
 
 **Persistent Init Scripts** — Add a `--init-script` CLI argument to inject JavaScript on every page load via `page.evaluateOnNewDocument()`. Charlotte's `dev_inject` currently applies CSS/JS once and does not persist across navigations.
 

--- a/docs/CHARLOTTE_SPEC.md
+++ b/docs/CHARLOTTE_SPEC.md
@@ -1,6 +1,6 @@
 # Charlotte Technical Specification
 
-**Version:** 0.6.1
+**Version:** 0.6.2
 
 Charlotte is an MCP server that renders web pages into structured, agent-readable `PageRepresentation` objects using headless Chromium and Puppeteer. It communicates over stdio using the Model Context Protocol.
 
@@ -237,6 +237,8 @@ interface IframeInfo {
 Present when child frames are discovered during rendering. Interactive elements from iframes are merged into the parent `interactive` array and `interactive_summary`. Content summaries and full text are appended with iframe URL prefixes.
 
 Iframe discovery depth is configurable (default: 3 levels).
+
+Interaction tools (click, type, select, toggle, submit, scroll, hover, key, wait_for, upload, fill_form) resolve element IDs to their owning frame and dispatch actions against that frame's CDP session. Cross-frame operations — such as dragging between elements in different frames — are rejected with a `CharlotteError`.
 
 ---
 

--- a/docs/playwright-mcp-gap-analysis.md
+++ b/docs/playwright-mcp-gap-analysis.md
@@ -402,14 +402,14 @@ Playwright MCP's entire `testing` capability group (5 tools) has no Charlotte eq
 | **Impact** | Medium — useful for injecting polyfills, analytics blockers, or auth tokens on every page load |
 | **Suggested Change** | Add `--init-script` CLI argument that injects via `page.evaluateOnNewDocument()` |
 
-### GAP-33: Connect to Existing Browser
+### GAP-33: Connect to Existing Browser — *remediated in v0.6.2*
 
 | Attribute | Detail |
 |-----------|--------|
 | **Playwright Feature** | `--extension` mode to connect to existing Chrome/Edge, `--cdp-endpoint` to connect via DevTools Protocol |
-| **Charlotte Status** | Not implemented — always launches a new browser instance |
+| **Charlotte Status** | Implemented. `--cdp-endpoint <url>` connects via `puppeteer.connect()`; shorthand `channel:chrome` auto-discovers a local Chrome DevTools endpoint. `BrowserManager` gains a connected mode and `PageManager.adoptExistingPages()` picks up pre-existing tabs. Viewport of pre-existing pages is preserved. |
 | **Impact** | Medium — connecting to a user's existing browser enables working with logged-in sessions, extensions, etc. |
-| **Suggested Change** | Add `--cdp-endpoint` CLI argument to BrowserManager to connect via `puppeteer.connect()` |
+| **Suggested Change** | *Implemented in v0.6.2.* |
 
 ### GAP-34: Forward Navigation
 
@@ -547,7 +547,7 @@ Features Charlotte provides that Playwright MCP **does not** have as dedicated t
 | GAP-05 | `slowly` param on `type` | Fixes autocomplete and search-as-you-type sites — *remediated in v0.6.0* |
 | GAP-06 | `modifiers` param on `click` | Enables Ctrl+Click, Shift+Click patterns |
 | GAP-13 | `filename` param on tools | Reduces token consumption for large outputs |
-| GAP-33 | `--cdp-endpoint` CLI arg | Enables connecting to existing browser sessions |
+| GAP-33 | `--cdp-endpoint` CLI arg | Enables connecting to existing browser sessions — *remediated in v0.6.2* |
 | GAP-32 | `--init-script` CLI arg | Persistent script injection across navigations |
 | GAP-38 | `--config` CLI arg | Simplifies repeatable setups |
 
@@ -613,7 +613,7 @@ Features Charlotte provides that Playwright MCP **does not** have as dedicated t
 | GAP-30 | Session | Custom user agent | `--user-agent` | Missing | Low-Med |
 | GAP-31 | Session | Permission granting | `--grant-permissions` | Missing | Low |
 | GAP-32 | Session | Persistent init scripts | `--init-script` | Partial | Medium |
-| GAP-33 | Session | Connect to existing browser | `--cdp-endpoint` / `--extension` | Missing | Medium |
+| GAP-33 | Session | Connect to existing browser | `--cdp-endpoint` / `--extension` | Remediated in v0.6.2 | Medium |
 | GAP-34 | Session | Forward navigation | N/A | Charlotte has it | N/A |
 | GAP-35 | Transport | SSE transport | `--port` flag | Missing | Medium |
 | GAP-36 | Transport | Streamable HTTP | MCP spec endpoint | Missing | Medium |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Token-efficient browser MCP server — structured web pages for AI agents, not raw accessibility dumps",
   "type": "module",
   "main": "dist/index.js",

--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -19,6 +19,19 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "0.6.2",
+    date: "2026-04-16",
+    entries: [
+      { type: "added", text: "--cdp-endpoint CLI option — Connect to a running Chrome/Chromium instance via its DevTools Protocol endpoint instead of launching a new browser. Supports ws:// URLs and channel:chrome shorthand. Closes GAP-33." },
+      { type: "added", text: "Iframe interaction — Interaction tools (click, type, select, toggle, submit, scroll, hover, key, wait_for, upload, fill_form) now work against elements inside child frames. Closes #66." },
+      { type: "changed", text: "Reduced CDP session churn — Interaction helpers reuse CDP sessions instead of repeatedly attaching and detaching. Closes #113." },
+      { type: "fixed", text: "Cross-frame drag validation — charlotte_drag now rejects drags between elements in different frames with a CharlotteError instead of silently producing undefined behavior." },
+      { type: "fixed", text: "Stale frame sessions in CDPSessionManager — Frame sessions are cleaned up on frame detach and empty reverse-index entries are pruned. Closes #67." },
+      { type: "fixed", text: "Batched startup tool.disable() into a single sendToolListChanged() notification, mirroring the v0.6.1 runtime fix." },
+      { type: "fixed", text: "Viewport of pre-existing pages is preserved when connecting via --cdp-endpoint." },
+    ],
+  },
+  {
     version: "0.6.1",
     date: "2026-04-09",
     entries: [


### PR DESCRIPTION
## Summary

Docs + version bump for the v0.6.2 release. No source changes.

### Headline changes in v0.6.2

- `--cdp-endpoint` CLI option — connect to a running Chrome/Chromium via DevTools Protocol. Closes GAP-33. (#153)
- Iframe interaction — all interaction tools now work against elements inside child frames. (#66, #160)
- Cross-frame drag surfaces a `CharlotteError` instead of undefined behavior.
- `CDPSessionManager` cleans up stale frame sessions. (#67, #155)
- Startup `tool.disable()` batched into a single `sendToolListChanged()`. (#158)
- Reduced CDP session churn in interaction helpers. (#113, #159)
- CI workflow (#154) and end-to-end MCP protocol tests (#60).

### Files touched

- `package.json` — 0.6.1 → 0.6.2 (server.ts reads dynamically)
- `CHANGELOG.md` — v0.6.2 section
- `README.md` — benchmark header, iframe-aware interaction note, roadmap pruned
- `docs/CHARLOTTE_SPEC.md` — version bump + iframe interaction description
- `docs/playwright-mcp-gap-analysis.md` — GAP-33 marked remediated
- `site/app/changelog/page.tsx` — v0.6.2 entry (test/CI omitted per policy)

## Test plan

- [x] `npm test` — 599/599 passed (44 files)
- [x] `npx tsc --noEmit` — clean
- [x] Cold review by Sonnet sub-agent — feedback applied
- [ ] Tag `v0.6.2` after merge
- [ ] `npm publish` after merge
- [ ] Deploy website (if applicable)

// ticktockbent