### PR TITLE
Release v0.6.3: republish with correct dist, add prepublishOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Charlotte will be documented in this file.
 
 <!-- Nothing yet -->
 
+## [0.6.3] - 2026-04-17
+
+### Fixed
+
+- **Republished with correct `dist/` artifacts** — The v0.6.2 tarball on npm was packaged from a stale `dist/` directory and did not actually include the `--cdp-endpoint` CLI option, iframe interaction, or other v0.6.2 source changes, despite those features being present at the v0.6.2 git tag. v0.6.3 ships the same intended feature set with the correct compiled output. No source-level changes versus v0.6.2. Fixes #164.
+
+### Internal
+
+- Added `prepublishOnly` script (`npm run build && npm test`) so `npm publish` rebuilds and re-tests before packaging, preventing stale-dist publishes.
+
 ## [0.6.2] - 2026-04-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ticktockbent/charlotte",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticktockbent/charlotte",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Token-efficient browser MCP server — structured web pages for AI agents, not raw accessibility dumps",
   "type": "module",
   "main": "dist/index.js",
@@ -37,6 +37,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build && npm test",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Fixes #164: the v0.6.2 tarball on npm was packaged from a stale `dist/` and does not actually contain `--cdp-endpoint`, iframe interaction, or other v0.6.2 features, despite those being present at the v0.6.2 git tag. Confirmed by `npm pack @ticktockbent/charlotte@0.6.2` — `dist/cli.js` has no `cdp-endpoint` references.
- v0.6.3 re-ships the same intended feature set with the correct compiled output. No source-level changes vs v0.6.2.
- Adds `"prepublishOnly": "npm run build && npm test"` so `npm publish` rebuilds (and re-tests) before packaging, preventing recurrence.

## Root cause
`package.json` had no `prepublishOnly` / `prepack` / `prepare` hook, so `npm publish` packaged whatever happened to be in `dist/` on the publisher's machine — which was a build from before PR #153 (`--cdp-endpoint`) was merged.

// ticktockbent