### PR TITLE
refactor: replace CDP send 'as any' casts with proper types

### DIFF
--- a/src/browser/cdp-session.ts
+++ b/src/browser/cdp-session.ts
@@ -6,6 +6,8 @@ const REQUIRED_DOMAINS = ["Accessibility", "DOM", "CSS", "Page", "Network"] as c
 /** Domains needed for iframe frame sessions (subset — no Page/Network). */
 const FRAME_DOMAINS = ["Accessibility", "DOM", "CSS"] as const;
 
+type EnableableDomain = (typeof REQUIRED_DOMAINS)[number];
+
 export class CDPSessionManager {
   private sessions: WeakMap<Page, CDPSession> = new WeakMap();
   private frameSessions = new Map<string, CDPSession>();
@@ -118,10 +120,13 @@ export class CDPSessionManager {
     this.pageFrameIds.delete(page);
   }
 
-  private async enableDomains(session: CDPSession, domains: readonly string[]): Promise<void> {
+  private async enableDomains(
+    session: CDPSession,
+    domains: readonly EnableableDomain[],
+  ): Promise<void> {
     for (const domain of domains) {
       try {
-        await session.send(`${domain}.enable` as any);
+        await session.send(`${domain}.enable`);
         logger.debug(`Enabled CDP domain: ${domain}`);
       } catch (error) {
         // Some domains may not need explicit enabling

--- a/src/renderer/accessibility-extractor.ts
+++ b/src/renderer/accessibility-extractor.ts
@@ -90,9 +90,8 @@ export class AccessibilityExtractor {
   async extract(session: CDPSession, frameId?: string): Promise<ParsedAXNode[]> {
     logger.debug("Extracting accessibility tree", { frameId: frameId ?? "main" });
 
-    const params = frameId ? { frameId } : {};
-    const result = await session.send("Accessibility.getFullAXTree" as any, params);
-    const rawNodes: RawAXNode[] = (result as any).nodes;
+    const { nodes } = await session.send("Accessibility.getFullAXTree", frameId ? { frameId } : {});
+    const rawNodes = nodes as unknown as RawAXNode[];
 
     if (!rawNodes || rawNodes.length === 0) {
       logger.warn("Empty accessibility tree returned");

--- a/src/renderer/frame-discovery.ts
+++ b/src/renderer/frame-discovery.ts
@@ -132,13 +132,13 @@ async function getIframeBounds(
 ): Promise<Bounds | null> {
   try {
     // Get the frame owner (the <iframe> element in the parent DOM)
-    const { backendNodeId } = await parentSession.send("DOM.getFrameOwner" as any, {
+    const { backendNodeId } = await parentSession.send("DOM.getFrameOwner", {
       frameId: childFrameId,
     });
 
     if (!backendNodeId) return null;
 
-    const { model } = await parentSession.send("DOM.getBoxModel" as any, {
+    const { model } = await parentSession.send("DOM.getBoxModel", {
       backendNodeId,
     });
 

--- a/src/renderer/layout-extractor.ts
+++ b/src/renderer/layout-extractor.ts
@@ -7,11 +7,10 @@ export const ZERO_BOUNDS: Bounds = { x: 0, y: 0, w: 0, h: 0 };
 export class LayoutExtractor {
   async getBounds(session: CDPSession, backendNodeId: number): Promise<Bounds | null> {
     try {
-      const result = await session.send("DOM.getBoxModel" as any, {
+      const { model } = await session.send("DOM.getBoxModel", {
         backendNodeId,
       });
 
-      const model = (result as any).model;
       if (!model || !model.content) return null;
 
       // content quad is [x1,y1, x2,y2, x3,y3, x4,y4]


### PR DESCRIPTION
Closes #85.

## Summary

Removes `as any` from CDP `session.send()` call sites where Puppeteer's typed signature handles the method directly, and tightens the one dynamic call site so it still typechecks without a cast.

## Changes

- **`src/renderer/layout-extractor.ts`** — drop the cast on `DOM.getBoxModel`; destructure `model` from the typed result.
- **`src/renderer/frame-discovery.ts`** — drop the cast on `DOM.getFrameOwner` and `DOM.getBoxModel`; destructured returns already lined up with the typed shapes.
- **`src/renderer/accessibility-extractor.ts`** — drop the cast on `Accessibility.getFullAXTree` and on the result. The local `RawAXNode` interface is a narrower view than the protocol's `AXNode`, so an explicit `as unknown as RawAXNode[]` stays — but no `any` is involved.
- **`src/browser/cdp-session.ts`** — `enableDomains()` now takes a `readonly EnableableDomain[]` (the literal union of `REQUIRED_DOMAINS`), so the template literal `` `${domain}.enable` `` resolves to a known `keyof ProtocolMapping.Commands` and the call typechecks without a cast. The two `(frame as any).client` / `_id` accesses are unrelated (Puppeteer Frame internals tracked under #84) and untouched.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — `62 → 55` warnings (the seven removed warnings line up with the seven removed `as any` casts; no new lint errors)
- `npm run test:unit` — `319 / 319` passing
- `npm run test` (full) — same pass/fail set as `main` on this clone (the eight failures in `dialog.test.ts` / `interaction.test.ts` / `modifier-click.test.ts` reproduce on a clean checkout of `ac185fd` and look unrelated to CDP `send`; happy to dig deeper if it'd help)
- `npm run build` — clean
- `npx prettier --check src/**/*.ts` — clean