### PR TITLE
feat: add timeout guard for slow typing with large text inputs

### DIFF
--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -202,6 +202,20 @@ export function registerInteractionTools(
         const shouldPressEnter = press_enter ?? false;
         const delayMs = character_delay ?? (slowly ? 50 : undefined);
 
+        // Guard against excessively long typing duration
+        const MAX_TYPING_DURATION_MS = 30000; // 30 seconds
+        if (delayMs !== undefined) {
+          const estimatedDuration = text.length * delayMs;
+          if (estimatedDuration > MAX_TYPING_DURATION_MS) {
+            throw new CharlotteError(
+              CharlotteErrorCode.INVALID_ARGUMENT,
+              `Typing would take too long (${Math.round(estimatedDuration / 1000)}s). ` +
+                `Reduce text length (${text.length} chars) or character_delay (${delayMs}ms). ` +
+                `Maximum allowed duration: ${MAX_TYPING_DURATION_MS / 1000}s.`,
+            );
+          }
+        }
+
         logger.info("Typing into element", {
           element_id,
           textLength: text.length,


### PR DESCRIPTION
## Summary

Adds a timeout guard to `charlotte_type` to prevent excessively long typing operations that could hit MCP tool timeouts, as requested in #127.

## Problem

`charlotte_type` with `slowly: true` or `character_delay` has no upper bound on total typing duration. For example:
- 1000 characters at 50ms delay = 50 seconds
- 600 characters at 100ms delay = 60 seconds

This could easily exceed typical MCP tool timeout limits (often 30-60 seconds).

## Solution

### Added timeout guard

**Location**: `src/tools/interaction.ts` (lines 204-217)

**Logic**:
1. Define `MAX_TYPING_DURATION_MS = 30000` (30 seconds)
2. Calculate estimated duration: `text.length * delayMs`
3. If estimated duration exceeds the limit, throw `CharlotteError` with `INVALID_ARGUMENT` code
4. Provide helpful error message with actual duration and suggestions

### Example error message

```
Typing would take too long (50s). Reduce text length (1000 chars) or character_delay (50ms). Maximum allowed duration: 30s.
```

## Implementation Details

- **Self-contained**: All changes in `src/tools/interaction.ts`
- **Non-breaking**: Only affects edge cases that would likely timeout anyway
- **Early validation**: Fails fast before starting to type
- **Graceful**: Uses existing `CharlotteError` error handling

## Testing

### Manual testing scenarios

**Should succeed**:
- 500 chars at 50ms = 25s (under 30s limit)

**Should fail with helpful error**:
- 1000 chars at 50ms = 50s (over 30s limit)

**Fast typing unaffected**:
- No delay = instant typing, no limit

### Integration tests

Existing tests in `tests/integration/interaction.test.ts` cover slow typing and can be extended to test the timeout guard.

## Design Decisions

### Why 30 seconds?

- Conservative limit that allows reasonable slow-typing use cases
- Aligns with common MCP tool timeout defaults
- Can be adjusted if needed based on real-world usage

### Why fail early?

- Better UX: immediate feedback vs. waiting 30+ seconds then timing out
- Clearer error: explains the problem and suggests solutions
- Saves resources: does not start typing if it will fail anyway

### Why INVALID_ARGUMENT?

- The input combination (text length + delay) is invalid for the constraint
- Consistent with other validation errors in Charlotte
- Allows callers to catch and handle this specific case

## Future Enhancements (out of scope)

- Make `MAX_TYPING_DURATION_MS` configurable via environment variable
- Add warning (not error) at 20s threshold
- Auto-adjust delay to fit within timeout

## Related

- Fixes #127
- Introduced by PR #126 (select option cap + slow typing)

Fixes #127