### PR TITLE
feat: add timeout guard for slow typing with large text inputs (supersedes #174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Charlotte will be documented in this file.
 
 ### Added
 
-- **Slow-typing duration guard** — `charlotte_type` now rejects slow-typing requests whose estimated duration would risk an MCP tool timeout, failing fast with an `INVALID_ARGUMENT` error instead of starting to type and timing out partway. The estimate (`text.length * character_delay`) is capped at 30s and includes a margin for per-keystroke overhead. The `character_delay` schema description documents the ceiling so callers see it upfront. Fixes #127. (#174)
+- **Slow-typing duration guard** — `charlotte_type` now rejects slow-typing requests whose estimated duration would risk an MCP tool timeout, failing fast with an `INVALID_ARGUMENT` error instead of starting to type and timing out partway. The estimate (`text.length * character_delay`) is capped at 30s and includes a margin for per-keystroke overhead. The `character_delay` schema description documents the ceiling so callers see it upfront. Fixes #127. (#174, #180)
 
 ## [0.6.3] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to Charlotte will be documented in this file.
 
 ## [Unreleased]
 
-<!-- Nothing yet -->
+### Added
+
+- **Slow-typing duration guard** — `charlotte_type` now rejects slow-typing requests whose estimated duration would risk an MCP tool timeout, failing fast with an `INVALID_ARGUMENT` error instead of starting to type and timing out partway. The estimate (`text.length * character_delay`) is capped at 30s and includes a margin for per-keystroke overhead. The `character_delay` schema description documents the ceiling so callers see it upfront. Fixes #127. (#174)
 
 ## [0.6.3] - 2026-04-17
 

--- a/src/tools/interaction-helpers.ts
+++ b/src/tools/interaction-helpers.ts
@@ -29,6 +29,47 @@ export async function scrollAndGetCenter(
   };
 }
 
+/**
+ * Maximum total wall-clock duration we allow a slow-typing operation to take.
+ * Kept under common MCP tool timeout defaults (often 30–60s) so the guard
+ * fails fast with a helpful error instead of letting the tool call time out.
+ */
+export const MAX_TYPING_DURATION_MS = 30000; // 30 seconds
+
+/**
+ * Multiplier applied to the naive `text.length * characterDelayMs` estimate to
+ * account for per-keystroke overhead that the estimate ignores: Puppeteer's
+ * event dispatch, any clear_first keystrokes, and CDP round-trips. Without this
+ * margin a 29s estimate can tip over 30s in practice and still time out.
+ */
+const TYPING_OVERHEAD_FACTOR = 1.15;
+
+/**
+ * Guard against slow-typing operations that would run long enough to risk an
+ * MCP tool timeout. Throws a CharlotteError with INVALID_ARGUMENT when the
+ * estimated duration (with overhead margin) exceeds {@link MAX_TYPING_DURATION_MS}.
+ *
+ * No-op when `characterDelayMs` is undefined (full-speed typing is effectively
+ * instant and has no meaningful upper bound).
+ */
+export function assertTypingDurationWithinLimit(
+  textLength: number,
+  characterDelayMs: number | undefined,
+): void {
+  if (characterDelayMs === undefined) return;
+
+  const estimatedDurationMs = Math.round(textLength * characterDelayMs * TYPING_OVERHEAD_FACTOR);
+  if (estimatedDurationMs > MAX_TYPING_DURATION_MS) {
+    throw new CharlotteError(
+      CharlotteErrorCode.INVALID_ARGUMENT,
+      `Typing would take too long (~${Math.round(estimatedDurationMs / 1000)}s). ` +
+        `Maximum allowed duration: ${MAX_TYPING_DURATION_MS / 1000}s.`,
+      `Reduce text length (currently ${textLength} chars) or character_delay (currently ${characterDelayMs}ms), ` +
+        `or type at full speed by omitting slowly/character_delay.`,
+    );
+  }
+}
+
 /** Maps short modifier names to Puppeteer KeyInput values. */
 export const MODIFIER_KEY_MAP: Record<string, KeyInput> = {
   ctrl: "Control" as KeyInput,

--- a/src/tools/interaction-helpers.ts
+++ b/src/tools/interaction-helpers.ts
@@ -44,6 +44,21 @@ export const MAX_TYPING_DURATION_MS = 30000; // 30 seconds
  */
 const TYPING_OVERHEAD_FACTOR = 1.15;
 
+/** Default inter-keystroke delay applied when `slowly` is requested without an explicit delay. */
+export const DEFAULT_SLOW_TYPING_DELAY_MS = 50;
+
+/**
+ * Resolve the effective inter-keystroke delay for a type operation.
+ * An explicit `characterDelay` always wins; otherwise `slowly: true` implies
+ * {@link DEFAULT_SLOW_TYPING_DELAY_MS}, and full-speed typing returns undefined.
+ */
+export function resolveCharacterDelay(
+  slowly: boolean | undefined,
+  characterDelay: number | undefined,
+): number | undefined {
+  return characterDelay ?? (slowly ? DEFAULT_SLOW_TYPING_DELAY_MS : undefined);
+}
+
 /**
  * Guard against slow-typing operations that would run long enough to risk an
  * MCP tool timeout. Throws a CharlotteError with INVALID_ARGUMENT when the

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -27,6 +27,7 @@ import {
   submitFormByBackendNodeId,
   setFileInputFiles,
   waitForPossibleNavigation,
+  assertTypingDurationWithinLimit,
 } from "./interaction-helpers.js";
 import { registerWaitForTools } from "./wait-for.js";
 
@@ -189,7 +190,8 @@ export function registerInteractionTools(
           .min(1)
           .optional()
           .describe(
-            "Milliseconds between keystrokes (implies slowly: true). Default when slowly is true: 50ms",
+            "Milliseconds between keystrokes (implies slowly: true). Default when slowly is true: 50ms. " +
+              "Total typing time is capped at 30s — text.length * character_delay must stay under that ceiling or the call is rejected.",
           ),
       },
     },
@@ -202,19 +204,8 @@ export function registerInteractionTools(
         const shouldPressEnter = press_enter ?? false;
         const delayMs = character_delay ?? (slowly ? 50 : undefined);
 
-        // Guard against excessively long typing duration
-        const MAX_TYPING_DURATION_MS = 30000; // 30 seconds
-        if (delayMs !== undefined) {
-          const estimatedDuration = text.length * delayMs;
-          if (estimatedDuration > MAX_TYPING_DURATION_MS) {
-            throw new CharlotteError(
-              CharlotteErrorCode.INVALID_ARGUMENT,
-              `Typing would take too long (${Math.round(estimatedDuration / 1000)}s). ` +
-                `Reduce text length (${text.length} chars) or character_delay (${delayMs}ms). ` +
-                `Maximum allowed duration: ${MAX_TYPING_DURATION_MS / 1000}s.`,
-            );
-          }
-        }
+        // Guard against slow-typing operations long enough to risk an MCP tool timeout.
+        assertTypingDurationWithinLimit(text.length, delayMs);
 
         logger.info("Typing into element", {
           element_id,

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -28,6 +28,7 @@ import {
   setFileInputFiles,
   waitForPossibleNavigation,
   assertTypingDurationWithinLimit,
+  resolveCharacterDelay,
 } from "./interaction-helpers.js";
 import { registerWaitForTools } from "./wait-for.js";
 
@@ -191,21 +192,24 @@ export function registerInteractionTools(
           .optional()
           .describe(
             "Milliseconds between keystrokes (implies slowly: true). Default when slowly is true: 50ms. " +
-              "Total typing time is capped at 30s — text.length * character_delay must stay under that ceiling or the call is rejected.",
+              "Total typing time is capped at approximately 30s (including per-keystroke overhead); " +
+              "requests whose estimated duration exceeds that are rejected.",
           ),
       },
     },
     async ({ element_id, text, clear_first, press_enter, slowly, character_delay }) => {
       try {
+        const shouldClearFirst = clear_first ?? true;
+        const shouldPressEnter = press_enter ?? false;
+        const delayMs = resolveCharacterDelay(slowly, character_delay);
+
+        // Pure argument validation — guard against slow-typing operations long
+        // enough to risk an MCP tool timeout before doing any browser work.
+        assertTypingDurationWithinLimit(text.length, delayMs);
+
         await ensureReady(deps);
         const resolved = await resolveElement(deps, element_id);
         const session = await getSessionForElement(deps, resolved);
-        const shouldClearFirst = clear_first ?? true;
-        const shouldPressEnter = press_enter ?? false;
-        const delayMs = character_delay ?? (slowly ? 50 : undefined);
-
-        // Guard against slow-typing operations long enough to risk an MCP tool timeout.
-        assertTypingDurationWithinLimit(text.length, delayMs);
 
         logger.info("Typing into element", {
           element_id,

--- a/src/tools/interaction.ts
+++ b/src/tools/interaction.ts
@@ -202,6 +202,20 @@ export function registerInteractionTools(
         const shouldPressEnter = press_enter ?? false;
         const delayMs = character_delay ?? (slowly ? 50 : undefined);
 
+        // Guard against excessively long typing duration
+        const MAX_TYPING_DURATION_MS = 30000; // 30 seconds
+        if (delayMs !== undefined) {
+          const estimatedDuration = text.length * delayMs;
+          if (estimatedDuration > MAX_TYPING_DURATION_MS) {
+            throw new CharlotteError(
+              CharlotteErrorCode.INVALID_ARGUMENT,
+              `Typing would take too long (${Math.round(estimatedDuration / 1000)}s). ` +
+                `Reduce text length (${text.length} chars) or character_delay (${delayMs}ms). ` +
+                `Maximum allowed duration: ${MAX_TYPING_DURATION_MS / 1000}s.`,
+            );
+          }
+        }
+
         logger.info("Typing into element", {
           element_id,
           textLength: text.length,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -6,6 +6,7 @@ export enum CharlotteErrorCode {
   EVALUATION_ERROR = "EVALUATION_ERROR",
   SESSION_ERROR = "SESSION_ERROR",
   SNAPSHOT_EXPIRED = "SNAPSHOT_EXPIRED",
+  INVALID_ARGUMENT = "INVALID_ARGUMENT",
 }
 
 export class CharlotteError extends Error {

--- a/tests/unit/tools/typing-duration-guard.test.ts
+++ b/tests/unit/tools/typing-duration-guard.test.ts
@@ -1,9 +1,27 @@
 import { describe, it, expect } from "vitest";
 import {
   assertTypingDurationWithinLimit,
+  resolveCharacterDelay,
   MAX_TYPING_DURATION_MS,
+  DEFAULT_SLOW_TYPING_DELAY_MS,
 } from "../../../src/tools/interaction-helpers.js";
 import { CharlotteError, CharlotteErrorCode } from "../../../src/types/errors.js";
+
+describe("resolveCharacterDelay", () => {
+  it("returns undefined for full-speed typing (no slowly, no delay)", () => {
+    expect(resolveCharacterDelay(undefined, undefined)).toBeUndefined();
+    expect(resolveCharacterDelay(false, undefined)).toBeUndefined();
+  });
+
+  it("defaults to 50ms when slowly is true without an explicit delay", () => {
+    expect(resolveCharacterDelay(true, undefined)).toBe(DEFAULT_SLOW_TYPING_DELAY_MS);
+  });
+
+  it("prefers an explicit character_delay over the slowly default", () => {
+    expect(resolveCharacterDelay(true, 120)).toBe(120);
+    expect(resolveCharacterDelay(undefined, 120)).toBe(120);
+  });
+});
 
 describe("assertTypingDurationWithinLimit", () => {
   it("is a no-op when character delay is undefined (full-speed typing)", () => {
@@ -35,5 +53,12 @@ describe("assertTypingDurationWithinLimit", () => {
     const naiveEstimateMs = 595 * 50;
     expect(naiveEstimateMs).toBeLessThan(MAX_TYPING_DURATION_MS);
     expect(() => assertTypingDurationWithinLimit(595, 50)).toThrow(CharlotteError);
+  });
+
+  it("rejects a large slowly:true request via the resolved default delay", () => {
+    // Mirrors the tool handler path: slowly true with no explicit delay resolves
+    // to 50ms, and a large text then exceeds the cap.
+    const delayMs = resolveCharacterDelay(true, undefined);
+    expect(() => assertTypingDurationWithinLimit(2000, delayMs)).toThrow(CharlotteError);
   });
 });

--- a/tests/unit/tools/typing-duration-guard.test.ts
+++ b/tests/unit/tools/typing-duration-guard.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertTypingDurationWithinLimit,
+  MAX_TYPING_DURATION_MS,
+} from "../../../src/tools/interaction-helpers.js";
+import { CharlotteError, CharlotteErrorCode } from "../../../src/types/errors.js";
+
+describe("assertTypingDurationWithinLimit", () => {
+  it("is a no-op when character delay is undefined (full-speed typing)", () => {
+    expect(() => assertTypingDurationWithinLimit(100000, undefined)).not.toThrow();
+  });
+
+  it("allows typing that stays comfortably under the cap", () => {
+    // 100 chars * 50ms = 5s (well under 30s even with overhead margin)
+    expect(() => assertTypingDurationWithinLimit(100, 50)).not.toThrow();
+  });
+
+  it("throws CharlotteError with INVALID_ARGUMENT when estimate exceeds the cap", () => {
+    // 1000 chars * 50ms = 50s, far over the 30s ceiling
+    let thrown: unknown;
+    try {
+      assertTypingDurationWithinLimit(1000, 50);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(CharlotteError);
+    expect((thrown as CharlotteError).code).toBe(CharlotteErrorCode.INVALID_ARGUMENT);
+    expect((thrown as CharlotteError).message).toContain("too long");
+  });
+
+  it("accounts for keystroke overhead so a naive sub-cap estimate can still be rejected", () => {
+    // 595 chars * 50ms = 29.75s naively (under 30s), but with the overhead
+    // margin it tips over the ceiling and must be rejected.
+    const naiveEstimateMs = 595 * 50;
+    expect(naiveEstimateMs).toBeLessThan(MAX_TYPING_DURATION_MS);
+    expect(() => assertTypingDurationWithinLimit(595, 50)).toThrow(CharlotteError);
+  });
+});


### PR DESCRIPTION
Continues @xxiaoxiong's work in #174 (closed; the branch lived on a fork with maintainer edits disabled, so this PR carries their original commit plus the requested review changes on top). Fixes #127.

## Summary

Adds a duration guard to `charlotte_type` so slow-typing requests that would run long enough to hit an MCP tool timeout fail fast with a clear `INVALID_ARGUMENT` error, instead of starting to type and timing out partway through.

## What's in this PR

The original commit (`feat: add timeout guard...`) is preserved with @xxiaoxiong as author. A follow-up commit addresses the review on #174:

1. **Tests** — new unit tests in `tests/unit/tools/typing-duration-guard.test.ts` cover the no-delay no-op, an under-cap pass, an over-cap rejection (asserts `CharlotteError` with `INVALID_ARGUMENT`), and the overhead-margin edge case.
2. **Schema description** — `character_delay`'s `.describe()` now documents the 30s ceiling so LLM callers see the limit upfront rather than discovering it at runtime.
3. **Overhead margin** — the duration estimate now applies a 1.15x factor to account for per-keystroke / `clear_first` overhead the naive `text.length * character_delay` estimate ignored, so a ~29s estimate that would tip over 30s in practice is correctly rejected.

## Additional fix

- Added `INVALID_ARGUMENT` to `CharlotteErrorCode`. The original commit referenced this code but it did not exist in the enum, so it did not compile. The guard logic was also extracted into a pure, exported `assertTypingDurationWithinLimit()` helper in `interaction-helpers.ts` to make it unit-testable.

## Verification

- `npx tsc --noEmit` — clean
- `npm run test:unit` — 323 passed

// ticktockbent