### PR TITLE
Fix flaky dialog integration test from post-navigation click race (#166)

### DIFF
--- a/tests/integration/dialog.test.ts
+++ b/tests/integration/dialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import * as path from "node:path";
 import * as os from "node:os";
 import { BrowserManager } from "../../src/browser/browser-manager.js";
@@ -62,6 +62,25 @@ describe("Dialog integration", () => {
   });
 
   /**
+   * Defense-in-depth: never let a blocked page or a still-registered dialog leak
+   * into the next test. If an assertion fails mid-flow before a test reaches its
+   * own cleanup, the page can stay blocked on a dialog whose handler would then
+   * fire against the next test's page (and any in-flight click promise stays
+   * pending, surfacing later as an unhandled rejection). (#166)
+   */
+  afterEach(async () => {
+    const leakedDialog = pageManager.getPendingDialog();
+    if (leakedDialog) {
+      try {
+        await leakedDialog.accept();
+      } catch {
+        // Dialog already handled or detached — nothing to clean up.
+      }
+      pageManager.clearPendingDialog();
+    }
+  });
+
+  /**
    * Helper: dismiss any pending dialog and clear state, then navigate fresh.
    * Handles the case where a previous test left a beforeunload handler registered.
    */
@@ -87,6 +106,13 @@ describe("Dialog integration", () => {
 
     config.dialogAutoDismiss = "none";
     await page.goto(DIALOG_FIXTURE, { waitUntil: "load" });
+    // Wait for the main-world execution context to settle after navigation before
+    // any test issues a dialog-triggering click. A click that lands during the
+    // post-navigation context rebuild can resolve a stale backendDOMNodeId
+    // (DOM.resolveNode → "Node ... does not belong to the document"), silently fail
+    // to fire its dialog, and leave the next assertion seeing null. Successfully
+    // querying the context here forces it to be ready. (#166)
+    await page.waitForSelector("#alert-btn");
     pageManager.clearPendingDialog();
   }
 


### PR DESCRIPTION
Fixes #166.

## Problem

`tests/integration/dialog.test.ts` intermittently failed during the `prepublishOnly` run with `expected null not to be null` on `captures and accepts an alert dialog`, alongside an unhandled Puppeteer rejection (`DOM.resolveNode: "Node with given id does not belong to the document"`). It blocked `npm publish` but didn't reproduce in CI or isolated single-file runs — only under full-suite load.

## Root cause

The tests trigger dialogs with `page.click(selector)` immediately after the `beforeEach` navigation. Under full-suite load, the click's internal `Frame.$` adopts a `backendDOMNodeId` from the document being swapped out during the post-navigation execution-context rebuild. The handle adoption fails, the click silently never fires its dialog, the next assertion sees `null`, and the late internal rejection surfaces against whichever test is running.

## Fix

Test-only changes — no source changes:

1. `cleanNavigate()` now `await page.waitForSelector("#alert-btn")` after `goto`. Successfully querying the main-world context forces it to settle before any test clicks, closing the race window. This is the actual fix.
2. Added an `afterEach` that drains a leaked pending dialog, so a mid-flow assertion failure can't leave the page blocked (or a click promise pending) into the next test — the "missing cleanup between tests" the issue calls out. Defense-in-depth.

## Verification

- `npx tsc --noEmit` clean
- Dialog file: 25/25 across repeated isolated loops
- Full suite under load: 607/607 across 45 files, zero `ProtocolError`/unhandled rejections

Note: a rare load-dependent flake can't be proven gone since it never reproduced locally, but this removes the documented Puppeteer race directly and hardens cross-test state.

// ticktockbent