### PR TITLE
fix(cdp): re-attach after a dropped transport instead of wedging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Charlotte will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **CDP attach now recovers from a dropped transport.** Previously, once the control websocket to a `--cdp-endpoint` browser was lost (most commonly after the host slept), every subsequent tool call failed with "Cannot reconnect in CDP mode" until Charlotte was restarted. Charlotte now re-attaches to the endpoint on the next tool call and re-runs page adoption, reusing the existing crash-recovery state reset (#201). A clear error is only raised if the re-attach itself fails (the remote browser is genuinely gone).
+
 ## [0.7.0] - 2026-06-09
 
 This release hardens Charlotte for untrusted pages, fixes a long tail of silent-failure and lifecycle bugs, cuts per-render overhead, and adds a JSON configuration file. Read the **Behavior changes** below before upgrading — two of them (sandbox default, element-ID format) can affect existing setups.

--- a/src/browser/browser-manager.ts
+++ b/src/browser/browser-manager.ts
@@ -198,19 +198,33 @@ export class BrowserManager {
     }
 
     if (this.cdpEndpoint) {
-      // A lost transport cannot be recovered in CDP mode: only fail once the
-      // browser is actually gone (a connected-but-unadopted session falls
-      // through to retry adoption below).
-      if (this.firstConnectDone && (!this.browser || !this.browser.connected)) {
-        throw new CharlotteError(
-          CharlotteErrorCode.SESSION_ERROR,
-          "Remote browser disconnected. Cannot reconnect in CDP mode — restart the remote browser and Charlotte.",
-        );
+      // A previously-established CDP transport was lost, most often because the
+      // host slept and the control websocket dropped while the remote browser
+      // itself stayed alive. Re-attach instead of failing permanently: for
+      // browserURL and channel endpoints puppeteer.connect re-resolves the live
+      // target, so the session transparently recovers on the next tool call.
+      // handleDisconnect() has already reset per-session state (#201) and
+      // connectAndAdopt() re-runs page adoption, so we land on a clean tab.
+      const reconnecting = this.firstConnectDone && (!this.browser || !this.browser.connected);
+      if (reconnecting) {
+        logger.warn("Remote browser transport lost; re-attaching via CDP", {
+          endpoint: this.cdpEndpoint,
+        });
       }
 
       this.launching = this.connectAndAdopt();
       try {
         await this.launching;
+      } catch (error) {
+        // Reconnect genuinely failed (e.g. the remote browser is really gone).
+        // Surface a clear, actionable error rather than a raw puppeteer stack.
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new CharlotteError(
+          CharlotteErrorCode.SESSION_ERROR,
+          reconnecting
+            ? `Remote browser disconnected and re-attach to ${this.cdpEndpoint} failed; is the remote browser still running? (${detail})`
+            : `Failed to connect to remote browser at ${this.cdpEndpoint} (${detail})`,
+        );
       } finally {
         this.launching = null;
       }

--- a/tests/unit/browser/browser-manager.test.ts
+++ b/tests/unit/browser/browser-manager.test.ts
@@ -190,8 +190,38 @@ describe("BrowserManager", () => {
       expect(onFirstConnect).toHaveBeenCalledTimes(1);
     });
 
-    it("ensureConnected() throws when remote browser disconnects", async () => {
-      const mockBrowser = {
+    it("ensureConnected() re-attaches when the remote browser disconnects", async () => {
+      // After a host sleep the CDP transport drops while Chrome stays alive.
+      // ensureConnected() should re-attach (puppeteer.connect again) instead of
+      // failing permanently.
+      const makeBrowser = () => ({
+        connected: true,
+        on: vi.fn(),
+        close: vi.fn(),
+        disconnect: vi.fn(),
+        process: () => null,
+        pages: vi.fn().mockResolvedValue([]),
+      });
+      const first = makeBrowser();
+      const second = makeBrowser();
+      (puppeteer.connect as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce(second);
+
+      const manager = new BrowserManager(undefined, undefined, "http://localhost:9222");
+      await manager.launch();
+      expect(puppeteer.connect).toHaveBeenCalledTimes(1);
+
+      // Simulate the transport dropping.
+      first.connected = false;
+
+      await manager.ensureConnected();
+      expect(puppeteer.connect).toHaveBeenCalledTimes(2);
+      expect(manager.isConnected()).toBe(true);
+    });
+
+    it("ensureConnected() surfaces a clear error if re-attach fails", async () => {
+      const first = {
         connected: true,
         on: vi.fn(),
         close: vi.fn(),
@@ -199,15 +229,17 @@ describe("BrowserManager", () => {
         process: () => null,
         pages: vi.fn().mockResolvedValue([]),
       };
-      (puppeteer.connect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockBrowser);
+      (puppeteer.connect as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(first)
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
       const manager = new BrowserManager(undefined, undefined, "http://localhost:9222");
       await manager.launch();
 
-      // Simulate disconnection
-      mockBrowser.connected = false;
+      // Transport drops, and the remote browser is genuinely gone.
+      first.connected = false;
 
-      await expect(manager.ensureConnected()).rejects.toThrow("Remote browser disconnected");
+      await expect(manager.ensureConnected()).rejects.toThrow(/re-attach .* failed/);
     });
   });
 


### PR DESCRIPTION
## Problem

In CDP attach mode (`--cdp-endpoint`), once the control websocket to the remote browser drops, every subsequent tool call fails with:

> `Remote browser disconnected. Cannot reconnect in CDP mode — restart the remote browser and Charlotte.`

...and stays broken until Charlotte itself is restarted. The most common trigger is the **host going to sleep**: the long-lived CDP control socket dies, but the remote Chrome is still alive and happily accepting new CDP clients. For a long-running MCP server attached to a persistent Chrome (a logged-in debug profile on `:9222`), this means a manual restart after every sleep.

## Fix

`ensureConnected()` now **re-attaches** to the endpoint on the next tool call instead of failing permanently:

- For `browserURL` / `channel:` endpoints `puppeteer.connect` re-resolves the live target, so the session transparently recovers.
- It reuses the per-session state reset already wired up for crash recovery (#201) via the `disconnected` handler, and `connectAndAdopt()` re-runs page adoption, so the recovered call lands on a clean tab (consistent with the launch-mode relaunch path).
- A `SESSION_ERROR` is now raised **only** when the re-attach itself fails (the remote browser is genuinely gone), with a clearer, actionable message.

This makes CDP mode behave like the launch mode, which already auto-recovers from a Chromium crash (#201).

## Tests

- Updated the existing CDP-disconnect unit test to assert re-attach (a second `puppeteer.connect`, `isConnected()` true) rather than a throw.
- Added a test that a failing re-attach surfaces a clear error.
- Full unit suite green (`vitest run tests/unit/`, 594 tests), lint and prettier clean, `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)