### PR TITLE
fix: docker smoke test vs post-0.7.0 safe defaults

### DIFF
--- a/tests/docker-smoke-test.mjs
+++ b/tests/docker-smoke-test.mjs
@@ -36,6 +36,11 @@ function startContainer() {
       if (line.trim() && pendingResolve) {
         try {
           const parsed = JSON.parse(line.trim());
+          if (parsed.id === undefined) {
+            // Server-initiated notification (e.g. tools/list_changed after a
+            // charlotte_tools enable) — not the response we are waiting for.
+            continue;
+          }
           const resolve = pendingResolve;
           pendingResolve = null;
           resolve(parsed);
@@ -236,7 +241,12 @@ async function runTests(container) {
   const screenshotOk = !response.error && response.result?.content?.[0];
   log("screenshot", screenshotOk, screenshotOk ? "image captured" : "failed");
 
-  // 15. Evaluate JS
+  // 15. Evaluate JS — disabled in the default browse profile since v0.7.0's
+  // safe-defaults hardening, so enable its group first via the meta-tool.
+  // This also exercises the runtime-toggle path in the shipped image.
+  response = await callTool(container, "charlotte_tools", { action: "enable", group: "evaluate" });
+  content = assertOk(response, "tools enable evaluate");
+  log("tools (enable evaluate)", true, "evaluate group enabled");
   response = await callTool(container, "charlotte_evaluate", { expression: "document.title" });
   content = assertOk(response, "evaluate");
   log("evaluate", content.length > 0, `result: ${content.slice(0, 60)}`);
@@ -261,7 +271,11 @@ async function runTests(container) {
   const diffOk = !response.error;
   log("diff", diffOk, diffOk ? "diff computed" : "diff failed");
 
-  // 20. Configure
+  // 20. Configure — the browse profile only enables the tabs subset of the
+  // session group, so enable the full group first (second runtime-toggle check).
+  response = await callTool(container, "charlotte_tools", { action: "enable", group: "session" });
+  content = assertOk(response, "tools enable session");
+  log("tools (enable session)", true, "session group enabled");
   response = await callTool(container, "charlotte_configure", { auto_snapshot: "every_action" });
   content = assertOk(response, "configure");
   log("configure", true, "config updated");


### PR DESCRIPTION
Unblocks the v0.8.0 publish. The smoke gate failed on the tag (before any push — registries untouched) because it predated the v0.7.0 profile hardening: charlotte_evaluate and charlotte_configure are no longer in the default browse profile. The test now enables their groups via charlotte_tools first (adding runtime-toggle coverage of the shipped image), and the JSON-RPC reader skips server-initiated notifications instead of consuming them as responses.

Verified locally against the CI-identical alpine build: 22/22 passed.

After merge: re-point the v0.8.0 tag to the merge commit and re-push to fire the publish.

// ticktockbent
