### PR TITLE
docs: bespoke /README hub for the Mintlify site

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,0 +1,68 @@
+---
+title: "Charlotte Documentation"
+description: "The documentation hub for Charlotte — the MCP server that makes the web readable for AI agents."
+icon: "book-open"
+---
+
+{/*
+  Bespoke docs hub — the partner page to the marketing site
+  (https://charlotte-rose.vercel.app). This page is deliberately NOT in
+  docs.json navigation: it serves the /README route as an orientation page
+  bridging the marketing site, the GitHub repo, and these docs.
+*/}
+
+**Charlotte** is an MCP server that gives AI agents structured, token-efficient
+access to the web — a compact orientation on arrival, targeted queries for
+specifics, full detail only on request. These docs cover running it, connecting
+it to claude.ai, and trusting it with a public endpoint.
+
+If you're deciding whether Charlotte is worth your time, the
+[marketing page](https://charlotte-rose.vercel.app) has the demo and the
+benchmark story. If you've already decided: the cards below are the fast path.
+
+## Start here
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/index">
+    One command to a live claude.ai connector — the shortest honest path.
+  </Card>
+  <Card title="Self-Hosting" icon="server" href="/self-hosting">
+    The durable setup: your own domain, a stable token, docker compose.
+  </Card>
+</CardGroup>
+
+## Reference
+
+<CardGroup cols={2}>
+  <Card title="Configuration" icon="sliders" href="/configuration">
+    Every config key, env var, and precedence rule.
+  </Card>
+  <Card title="Benchmarks" icon="chart-line" href="/benchmarks">
+    Measured numbers — including the ones we lose — with published methodology.
+  </Card>
+  <Card title="Docker" icon="docker" href="/docker">
+    Images, sandbox posture, and the demo-mode entrypoint.
+  </Card>
+  <Card title="Security" icon="shield-halved" href="/security">
+    The trust boundary, network guards, OAuth mechanics, and accepted risks.
+  </Card>
+</CardGroup>
+
+## Elsewhere
+
+<CardGroup cols={3}>
+  <Card title="Marketing site" icon="globe" href="https://charlotte-rose.vercel.app">
+    The pitch, the demo, the vs-Playwright story.
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/TickTockBent/charlotte">
+    Source, issues, canonical docs, benchmark evidence.
+  </Card>
+  <Card title="npm" icon="npm" href="https://www.npmjs.com/package/@ticktockbent/charlotte">
+    `@ticktockbent/charlotte` — the stdio server for Claude Code and friends.
+  </Card>
+</CardGroup>
+
+<Note>
+  Looking for release history? See the [changelog](/changelog) or
+  [GitHub releases](https://github.com/TickTockBent/charlotte/releases).
+</Note>


### PR DESCRIPTION
The hosted docs default to /README, which 404s after the docs-root restructure. This makes /README a deliberate hub — partner page to the marketing site: card nav to all docs pages + marketing/GitHub/npm links. Unlisted in the sidebar by design (index stays the landing). Validated with mint validate + broken-links --check-anchors.

Note: links use charlotte-rose.vercel.app (the site's current self-declared canonical) — joins the existing TODO(reconcile) sweep whenever the real domain lands.

// ticktockbent
