### PR TITLE
site: link marketing site to the Mintlify docs, close agent-manifest …

### DIFF
--- a/site/app/vs-playwright/page.tsx
+++ b/site/app/vs-playwright/page.tsx
@@ -915,7 +915,7 @@ export default function VsPlaywrightPage() {
               GitHub repository &rarr;
             </a>
             <a
-              href="https://github.com/TickTockBent/charlotte/blob/main/docs/charlotte-benchmark-report.md"
+              href="https://charlotte.mintlify.site/benchmarks"
               target="_blank"
               rel="noopener noreferrer"
               className="text-accent hover:text-accent/80 transition-colors"

--- a/site/components/Benchmarks.tsx
+++ b/site/components/Benchmarks.tsx
@@ -211,7 +211,7 @@ export default function Benchmarks() {
         {/* Link to full report */}
         <div className="mt-6">
           <a
-            href="https://github.com/TickTockBent/charlotte/blob/main/docs/charlotte-benchmark-report.md"
+            href="https://charlotte.mintlify.site/benchmarks"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-accent hover:text-accent/80 transition-colors"

--- a/site/components/Footer.tsx
+++ b/site/components/Footer.tsx
@@ -22,6 +22,15 @@ export default function Footer() {
           </a>
           <span className="text-surface-border">|</span>
           <a
+            href="https://charlotte.mintlify.site"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            Docs
+          </a>
+          <span className="text-surface-border">|</span>
+          <a
             href="https://github.com/TickTockBent/charlotte/blob/main/LICENSE"
             target="_blank"
             rel="noopener noreferrer"

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -117,6 +117,16 @@ export default function Hero() {
                 </svg>
                 npm
               </a>
+              <a
+                href="https://charlotte.mintlify.site"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-surface-border font-medium text-sm hover:bg-surface-hover transition-colors"
+                data-asm-action="navigate"
+                data-asm-intent="view-documentation"
+              >
+                Docs
+              </a>
             </div>
           </div>
 

--- a/site/components/QuickStart.tsx
+++ b/site/components/QuickStart.tsx
@@ -58,7 +58,7 @@ function RemoteSelfHost({ compact = false }: { compact?: boolean }) {
       </p>
       <div className="flex flex-wrap gap-4 pt-3 text-sm">
         <a
-          href="https://github.com/TickTockBent/charlotte/blob/main/SELF_HOSTING.md"
+          href="https://charlotte.mintlify.site/self-hosting"
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent hover:text-accent/80 transition-colors"
@@ -66,7 +66,7 @@ function RemoteSelfHost({ compact = false }: { compact?: boolean }) {
           Self-hosting guide &rarr;
         </a>
         <a
-          href="https://github.com/TickTockBent/charlotte/blob/main/SECURITY.md"
+          href="https://charlotte.mintlify.site/security"
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent hover:text-accent/80 transition-colors"
@@ -208,7 +208,7 @@ find({ type: "link" })
           Full setup guide &rarr;
         </a>
         <a
-          href="https://github.com/TickTockBent/charlotte/blob/main/SELF_HOSTING.md"
+          href="https://charlotte.mintlify.site/self-hosting"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-accent hover:text-accent/80 transition-colors"
@@ -216,7 +216,7 @@ find({ type: "link" })
           Self-hosting guide &rarr;
         </a>
         <a
-          href="https://github.com/TickTockBent/charlotte/blob/main/SECURITY.md"
+          href="https://charlotte.mintlify.site/security"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-accent hover:text-accent/80 transition-colors"

--- a/site/public/agents.json
+++ b/site/public/agents.json
@@ -3,12 +3,13 @@
 
   "site": {
     "name": "Charlotte",
-    "description": "Open-source MCP server that renders web pages into structured, agent-readable representations using headless Chromium. 43 tools for AI agents to navigate, observe, and interact with the web.",
+    "description": "Open-source MCP server that renders web pages into structured, agent-readable representations using headless Chromium. Runs locally over stdio or self-hosted as a remote HTTP server (Docker) that clients like claude.ai can connect to over a tunnel. 43 tools for AI agents to navigate, observe, and interact with the web.",
     "primary_language": "en",
     "contact": "https://github.com/TickTockBent/charlotte/issues",
     "sameAs": [
       "https://github.com/TickTockBent/charlotte",
-      "https://www.npmjs.com/package/@ticktockbent/charlotte"
+      "https://www.npmjs.com/package/@ticktockbent/charlotte",
+      "https://charlotte.mintlify.site"
     ]
   },
 
@@ -84,6 +85,19 @@
         "name": "Changelog",
         "path": "/changelog/",
         "description": "Release history from v0.1.0 to current."
+      },
+      {
+        "name": "Documentation",
+        "path": "https://charlotte.mintlify.site/",
+        "description": "Full documentation site: installation, self-hosting Charlotte Remote, security, Docker, configuration, benchmarks, and changelog.",
+        "children": [
+          { "name": "Self-Hosting", "path": "https://charlotte.mintlify.site/self-hosting", "description": "Run Charlotte as a remote HTTP server reachable from claude.ai and other remote MCP clients." },
+          { "name": "Security", "path": "https://charlotte.mintlify.site/security", "description": "Trust model, network guards, and operator token." },
+          { "name": "Docker", "path": "https://charlotte.mintlify.site/docker", "description": "Container images and docker run / compose usage." },
+          { "name": "Configuration", "path": "https://charlotte.mintlify.site/configuration", "description": "Tool profiles, gated groups, and client setup." },
+          { "name": "Benchmarks", "path": "https://charlotte.mintlify.site/benchmarks", "description": "Methodology and full benchmark data vs Playwright MCP." },
+          { "name": "Changelog", "path": "https://charlotte.mintlify.site/changelog", "description": "Release history." }
+        ]
       }
     ],
     "sitemap": "/sitemap.xml"


### PR DESCRIPTION
…gaps

The 0.8.0 marketing site and the new Mintlify OSS docs site (charlotte.mintlify.site) went live with no links between them, and the agents.json manifest didn't mention the remote/self-host capability.

- Repoint "learn more" links that have a rendered docs equivalent: SELF_HOSTING.md -> /self-hosting, SECURITY.md -> /security, charlotte-benchmark-report.md -> /benchmarks. Left mcp-setup.md, sandbox.md, CHARLOTTE_SPEC.md, and LICENSE on GitHub -- the docs site has no page covering local MCP-client setup, the sandbox site, or the spec.
- Add a Docs link to the footer and a Docs CTA in the hero.
- agents.json: describe the remote HTTP / self-host capability, add charlotte.mintlify.site to sameAs, and add a Documentation navigation section so agents crawling the manifest discover the docs.

// ticktockbent
