### PR TITLE
docs: point benchmark links at the benchmarks README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charlotte decomposes each page into a typed, structured representation — landm
 
 ### Benchmarks
 
-Measured on Charlotte v0.8.0 against [Playwright MCP](https://github.com/microsoft/playwright-mcp) v0.0.79, by characters returned per tool call on real websites (`npx tsx benchmarks/run-benchmarks.ts --suite comparison`), 2026-08-08. Raw results: [`benchmarks/results/raw/v0.8.0/`](benchmarks/results/raw/v0.8.0/).
+Measured on Charlotte v0.8.0 against [Playwright MCP](https://github.com/microsoft/playwright-mcp) v0.0.79, by characters returned per tool call on real websites (`npx tsx benchmarks/run-benchmarks.ts --suite comparison`), 2026-08-08. Methodology, instruments, and raw results: [`benchmarks/`](benchmarks/README.md).
 
 **Orientation cost** (what an agent pays to "see" a page on arrival):
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,7 +8,7 @@ Three things are measured, by three separate instruments:
 
 | Instrument | Question it answers | Published results |
 |:---|:---|:---|
-| `run-benchmarks.ts` | How many characters does each server return per tool call on real sites? | [`results/raw/v0.8.0/`](results/raw/v0.8.0/) |
+| `run-benchmarks.ts` | How many characters does each server return per tool call on real sites? | [`results/raw/v0.8.0/summary.md`](results/raw/v0.8.0/summary.md) |
 | `run-drift.ts` | Has Charlotte's orientation cost crept up across releases? | [`results/drift/2026-08-09/drift.md`](results/drift/2026-08-09/drift.md) |
 | `run-tasks.ts` | What does a whole realistic agent task cost, end to end? | [`results/tasks/2026-08-09/tasks.md`](results/tasks/2026-08-09/tasks.md) |
 

--- a/docs/benchmarks.mdx
+++ b/docs/benchmarks.mdx
@@ -5,13 +5,13 @@ icon: chart-line
 ---
 
 {/*
-  Canonical source: README.md ("Benchmarks" section) and benchmarks/results/
-  (tasks/, drift/, raw/ — the underlying JSON runs and generated reports) at
-  the repo root. Changes flow canonical → this page, not the reverse — update
-  the source data/README first, then mirror the change here.
+  Canonical source: README.md ("Benchmarks" section) and benchmarks/README.md
+  (which maps results/ — tasks/, drift/, raw/ — the underlying JSON runs and
+  generated reports) at the repo root. Changes flow canonical → this page, not
+  the reverse — update the source data/README first, then mirror the change here.
 */}
 
-Measured on Charlotte v0.8.0 against [Playwright MCP](https://github.com/microsoft/playwright-mcp) v0.0.79, by characters returned per tool call on real websites (`npx tsx benchmarks/run-benchmarks.ts --suite comparison`), 2026-08-08. Full raw results and methodology live in [`benchmarks/results/`](https://github.com/TickTockBent/charlotte/tree/main/benchmarks/results) on GitHub — this page is a summary, not the methodology document.
+Measured on Charlotte v0.8.0 against [Playwright MCP](https://github.com/microsoft/playwright-mcp) v0.0.79, by characters returned per tool call on real websites (`npx tsx benchmarks/run-benchmarks.ts --suite comparison`), 2026-08-08. Full raw results and methodology live in [`benchmarks/`](https://github.com/TickTockBent/charlotte/blob/main/benchmarks/README.md) on GitHub — this page is a summary, not the methodology document.
 
 ## Orientation cost
 


### PR DESCRIPTION
Links that landed on a bare directory listing now land on the orientation README instead:

- README.md "Benchmarks" — was benchmarks/results/raw/v0.8.0/
- docs/benchmarks.mdx intro — was the GitHub tree view of benchmarks/results/, plus the canonical-source maintainer note
- benchmarks/README.md — the run-benchmarks.ts row now points at that run's summary.md rather than the raw JSON directory

Deep links to drift.md and tasks.md in docs/benchmarks.mdx are left alone: those are the methodology documents themselves, not file lists, and the README already links onward to both.

// ticktockbent