### PR TITLE
fix(site): bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5043,9 +5043,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert #157: `nanoid` <3.3.18 (transitive via `@tailwindcss/postcss` → `postcss` in `site/`) — custom generators can loop indefinitely when size is zero. Lockfile-only semver-patch bump to 3.3.18; `next build` verified clean locally. Root-project CI doesn't cover `site/`, so the local build is the verification.

// ticktockbent