### PR TITLE
security: accept GHSA-jmr9-qjv8-65gv (extract-zip) with allowlisted audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci --ignore-scripts
-      # Fail on high-severity vulnerabilities; report lower severities as informational.
-      - run: npm audit --audit-level=high
+      # Fail on high/critical advisories EXCEPT the reviewed accepted-risk
+      # allowlist in scripts/audit-check.mts (each entry documented under
+      # "Known accepted risks" in docs/security.mdx).
+      - run: npm run audit:check
 
   test:
     name: Test (Node ${{ matrix.node-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - name: Install Chromium system dependencies
+        # A wedged Azure apt mirror hangs apt indefinitely (no default HTTP
+        # timeout), eating the whole 15-minute job budget. Fail fast + retry
+        # instead, and cap the step so a pathological hang costs 4 minutes.
+        timeout-minutes: 4
+        env:
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y --no-install-recommends \
             libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
             libcups2 libdrm2 libxkbcommon0 libxcomposite1 \
             libxdamage1 libxfixes3 libxrandr2 libgbm1 \
@@ -95,9 +101,15 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install Chromium system dependencies
+        # A wedged Azure apt mirror hangs apt indefinitely (no default HTTP
+        # timeout), eating the whole 15-minute job budget. Fail fast + retry
+        # instead, and cap the step so a pathological hang costs 4 minutes.
+        timeout-minutes: 4
+        env:
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y --no-install-recommends \
             libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
             libcups2 libdrm2 libxkbcommon0 libxcomposite1 \
             libxdamage1 libxfixes3 libxrandr2 libgbm1 \

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -53,6 +53,20 @@ Chromium's own sandbox is a load-bearing part of this model — the Docker image
 
 ## Known accepted risks
 
+- **GHSA-jmr9-qjv8-65gv** (`extract-zip` ≤ 2.0.1, high): unvalidated symlink
+  path traversal when extracting a malicious zip archive. Present transitively
+  through `puppeteer@24` → `@puppeteer/browsers@2`; **no patched version
+  exists** — the package is unmaintained and upstream resolved it by dropping
+  the dependency. Exposure is install-time only: extract-zip runs solely when
+  `@puppeteer/browsers` unpacks the Chromium archive it downloads from
+  Google's CDN over HTTPS. Charlotte never extracts archives at runtime, and
+  no untrusted party controls a zip it opens — exploitation would require
+  compromising the Chromium download itself, the same trust already placed in
+  the Chromium binary. Accepted 2026-08-18; will clear with the Puppeteer 25
+  upgrade (`@puppeteer/browsers` 3.x replaced extract-zip with `modern-tar`),
+  which is planned as its own verified slice rather than a security drive-by.
+  CI's audit gate carries this ID in its reviewed allowlist
+  (`scripts/audit-check.mts`) so new advisories still fail the build.
 - **GHSA-frvp-7c67-39w9** (`@hono/node-server` < 2.0.5, moderate): path
   traversal in that package's `serve-static` handler on **Windows** hosts via
   an encoded backslash. Present transitively through

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "report:remote": "tsx benchmarks/remote-report.ts",
     "lint": "eslint src/ tests/",
     "lint:docs": "tsx scripts/lint-docs.mts",
+    "audit:check": "tsx scripts/audit-check.mts",
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'"

--- a/scripts/audit-check.mts
+++ b/scripts/audit-check.mts
@@ -1,0 +1,113 @@
+/**
+ * CI audit gate: `npm audit` with a reviewed accepted-risk allowlist.
+ *
+ * Plain `npm audit --audit-level=high` cannot exempt an advisory, so an
+ * unpatchable transitive advisory leaves the job permanently red and trains
+ * everyone to ignore it. This script fails on any high/critical advisory
+ * EXCEPT the GHSA IDs explicitly allowlisted below. Every allowlist entry
+ * must have a matching entry in docs/security.mdx "Known accepted risks"
+ * (with rationale, acceptance date, and clearing condition) — the allowlist
+ * is the enforcement half of that document, not a place to park noise.
+ */
+import { execFileSync } from "node:child_process";
+
+/** GHSA IDs accepted per docs/security.mdx "Known accepted risks". */
+const ACCEPTED_ADVISORIES = new Set([
+  // extract-zip symlink traversal via puppeteer@24 -> @puppeteer/browsers@2.
+  // Install-time only (Chromium download from Google's CDN); no patch exists.
+  // Accepted 2026-08-18; clears with the Puppeteer 25 upgrade.
+  "GHSA-jmr9-qjv8-65gv",
+]);
+
+const FAILING_SEVERITIES = new Set(["high", "critical"]);
+
+interface AuditAdvisory {
+  severity: string;
+  url?: string;
+  title?: string;
+}
+
+interface AuditVulnerability {
+  name: string;
+  severity: string;
+  via: Array<string | AuditAdvisory>;
+}
+
+function ghsaIdFromUrl(url: string | undefined): string | undefined {
+  return url?.match(/GHSA-[a-z0-9-]+/i)?.[0];
+}
+
+function runNpmAudit(): Record<string, AuditVulnerability> {
+  let stdout: string;
+  try {
+    stdout = execFileSync("npm", ["audit", "--json"], { encoding: "utf8" });
+  } catch (error) {
+    // npm audit exits non-zero when vulnerabilities exist; the JSON report
+    // is still on stdout.
+    const failed = error as { stdout?: string };
+    if (!failed.stdout) throw error;
+    stdout = failed.stdout;
+  }
+  return (JSON.parse(stdout).vulnerabilities ?? {}) as Record<string, AuditVulnerability>;
+}
+
+function main() {
+  const vulnerabilities = runNpmAudit();
+
+  // A package fails if it carries a direct advisory that is failing-severity
+  // and not allowlisted, or if it inherits (via a package-name reference) from
+  // a package that fails. Iterate to a fixpoint to resolve inheritance chains.
+  const failing = new Set<string>();
+  const failureReasons = new Map<string, string>();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [packageName, vulnerability] of Object.entries(vulnerabilities)) {
+      if (failing.has(packageName)) continue;
+      for (const via of vulnerability.via) {
+        if (typeof via === "string") {
+          if (failing.has(via)) {
+            failing.add(packageName);
+            failureReasons.set(packageName, `inherits from ${via}`);
+            changed = true;
+            break;
+          }
+        } else if (FAILING_SEVERITIES.has(via.severity)) {
+          const ghsaId = ghsaIdFromUrl(via.url);
+          if (!ghsaId || !ACCEPTED_ADVISORIES.has(ghsaId)) {
+            failing.add(packageName);
+            failureReasons.set(packageName, `${ghsaId ?? via.url ?? "unknown"}: ${via.title ?? ""}`);
+            changed = true;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  const suppressedCount = Object.entries(vulnerabilities).filter(
+    ([packageName, vulnerability]) =>
+      !failing.has(packageName) && FAILING_SEVERITIES.has(vulnerability.severity),
+  ).length;
+
+  if (failing.size > 0) {
+    console.error("audit:check FAILED — high/critical advisories outside the accepted-risk allowlist:");
+    for (const packageName of failing) {
+      console.error(`  ${packageName} — ${failureReasons.get(packageName)}`);
+    }
+    console.error(
+      "\nFix the advisory, or (with maintainer sign-off) add its GHSA ID to ACCEPTED_ADVISORIES",
+    );
+    console.error('and document it under "Known accepted risks" in docs/security.mdx.');
+    process.exit(1);
+  }
+
+  console.log(
+    `audit:check OK — no unaccepted high/critical advisories` +
+      (suppressedCount > 0
+        ? ` (${suppressedCount} finding(s) suppressed by the reviewed allowlist: ${[...ACCEPTED_ADVISORIES].join(", ")})`
+        : ""),
+  );
+}
+
+main();


### PR DESCRIPTION
Dependabot alert #156: `extract-zip` ≤ 2.0.1 symlink path traversal, transitive via `puppeteer@24` → `@puppeteer/browsers@2`. **No patched version exists** — the package is unmaintained, and `@puppeteer/browsers` 3.x (Puppeteer 25) removed it entirely in favor of `modern-tar`.

## Risk acceptance

Exposure is install-time only: extract-zip runs solely when `@puppeteer/browsers` unpacks the Chromium archive downloaded from Google's CDN over HTTPS. Charlotte never extracts archives at runtime and no untrusted party controls a zip it opens — exploitation requires compromising the Chromium download itself. Accepted 2026-08-18 (maintainer sign-off in session); documented under **Known accepted risks** in `docs/security.mdx` with the clearing condition: the **Puppeteer 25 upgrade**, planned as its own verified slice (browser-engine major + `clickCount`→`count` rename), which drops extract-zip from the tree.

## CI audit gate

`npm audit --audit-level=high` cannot exempt an advisory, so this unpatchable finding would leave the audit job permanently red. The job now runs `npm run audit:check` (`scripts/audit-check.mts`): fails on any high/critical advisory except explicitly allowlisted GHSA IDs, each required to have a matching accepted-risk entry in the security docs. New advisories still fail the build.

**Verified both ways**: with the allowlist, 4 findings (the extract-zip inheritance chain) suppressed and exit 0; with an empty allowlist, exit 1 listing the full chain.

After merge: Dependabot alert #156 will be dismissed as tolerable risk referencing the docs entry. Alert #157 (nanoid) is fixed separately in #254.

// ticktockbent