### PR TITLE
ci: skip full CI for docs-only changes, add lightweight docs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    # Docs-only changes (docs/, the marketing site, root markdown) can't
+    # affect the build, tests, or audit — they get the lightweight docs.yml
+    # workflow (lint:docs) instead. A PR touching docs AND code still runs
+    # full CI: paths-ignore skips only when ALL changed files match.
+    paths-ignore:
+      - "docs/**"
+      - "site/**"
+      - "**.md"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "site/**"
+      - "**.md"
+      - "LICENSE"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+# Lightweight gate for docs-only changes. Full CI (ci.yml) ignores docs/,
+# site/, and markdown via paths-ignore; this workflow is the one check that
+# DOES care about docs/ — the GitHub-safe MDX lint (see CLAUDE.md "Docs").
+# Mixed docs+code PRs run both workflows; ci.yml's check job also runs
+# lint:docs, so the overlap is harmless.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-docs:
+    name: Docs lint (GitHub-safe MDX)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      # --ignore-scripts skips Puppeteer's Chromium download — not needed for lint
+      - run: npm ci --ignore-scripts
+      - run: npm run lint:docs


### PR DESCRIPTION
Docs-only changes can't affect the build, tests, or audit, but every Mintlify PR currently burns the full 3-job Chromium matrix (and rolls the apt-mirror dice three times).

- `ci.yml` gains `paths-ignore` (`docs/**`, `site/**`, `**.md`, `LICENSE`) on both push and pull_request triggers. paths-ignore skips the workflow only when **all** changed files match, so a PR touching docs *and* code still runs full CI.
- New `docs.yml` workflow runs only `npm run lint:docs` (the GitHub-safe MDX gate — the one check that genuinely covers `docs/`) on `docs/**` changes; ~30 seconds, no Chromium.
- Mixed PRs run both workflows; `ci.yml`'s check job also still runs `lint:docs`, so the overlap is a harmless double-check.
- No branch protection is configured on main, so skipped workflows can't block merges.

Both YAML files validated with a parse check. This PR touches `.github/` only, which is *not* ignored — full CI runs on it as proof the filters don't over-match.

// ticktockbent